### PR TITLE
Use the update:value event on input change, to support model binding.

### DIFF
--- a/src/components/LuxDatePicker.vue
+++ b/src/components/LuxDatePicker.vue
@@ -18,7 +18,7 @@
           :width="width"
           :size="size"
           :value="!date ? '' : date.toLocaleDateString('en-US')"
-          @inputvaluechange="updateInput($event)"
+          @update:value="updateInput($event)"
           v-on="inputEvents"
           :placeholder="placeholder"
           :helper="helper"
@@ -41,8 +41,7 @@
           :width="width"
           :size="size"
           :required="required"
-          :value="!range ? '' : formatStart() + ' - ' + formatEnd()"
-          @inputvaluechange="updateRangeInput($event)"
+          v-model:value="formattedRange"
           v-on="inputEvents.start"
           :placeholder="placeholder"
           :helper="helper"
@@ -59,7 +58,7 @@
  * existing vCalendar functionality.
  */
 import { DatePicker } from "v-calendar"
-import { ref, watchEffect } from "vue"
+import { ref, watchEffect, computed } from "vue"
 
 defineOptions({ name: "LuxDatePicker" })
 const props = defineProps({
@@ -196,6 +195,15 @@ const attributes = ref([
     },
   },
 ])
+
+const formattedRange = computed({
+  get() {
+    return !range.value ? "" : `${formatStart()} - ${formatEnd()}`
+  },
+  set(newValue) {
+    updateRangeInput(newValue)
+  },
+})
 
 function calendarClosedSingle(value) {
   if (date.value && isValidFormat(date.value.toLocaleDateString("en-US"))) {

--- a/src/components/LuxInputText.vue
+++ b/src/components/LuxInputText.vue
@@ -249,7 +249,7 @@ export default {
   },
   methods: {
     inputvaluechange(value) {
-      this.$emit("inputvaluechange", value)
+      this.$emit("update:value", value)
     },
     inputblur(value) {
       this.$emit("inputblur", value)

--- a/src/components/LuxInputText.vue
+++ b/src/components/LuxInputText.vue
@@ -76,7 +76,7 @@ export default {
   status: "ready",
   release: "1.0.0",
   type: "Element",
-  emits: ["inputvaluechange", "inputblur", "inputfocus"],
+  emits: ["inputvaluechange", "inputblur", "inputfocus", "update:value"],
   computed: {
     hasError() {
       return this.errormessage.length

--- a/tests/unit/specs/components/luxInputText.spec.js
+++ b/tests/unit/specs/components/luxInputText.spec.js
@@ -30,7 +30,7 @@ describe("LuxInputText.vue", () => {
 
     await input.setValue("I am writing in this input")
 
-    expect(wrapper.emitted().inputvaluechange.length).toEqual(1)
-    expect(wrapper.emitted().inputvaluechange[0]).toEqual(["I am writing in this input"])
+    expect(wrapper.emitted()["update:value"].length).toEqual(1)
+    expect(wrapper.emitted()["update:value"][0]).toEqual(["I am writing in this input"])
   })
 })


### PR DESCRIPTION
Without this we can't use v-model on LuxInputText, it only does one way binding.