### PR TITLE
Datepicker should not lose text when selecting a date

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vite build",
-    "test": "jest",
+    "test": "TZ=UTC jest",
     "lint": "vue-cli-service lint",
     "deploy": "npm run build; npm run styleguide:build; push-dir --dir=styleguide --branch=gh-pages --cleanup",
     "release": "npm run build && np && npm run deploy",

--- a/src/components/LuxDatePicker.vue
+++ b/src/components/LuxDatePicker.vue
@@ -4,12 +4,11 @@
       v-if="mode == 'single'"
       mode="single"
       :disabled-dates="disabledDates"
-      :update-on-input="true"
       :attributes="attributes"
       v-model="date"
       @popover-did-disappear="calendarClosedSingle($event)"
     >
-      <template #default="{ inputEvents }">
+      <template #default="{ inputValue, inputEvents }">
         <lux-input-text
           :id="id"
           :label="label"
@@ -17,9 +16,8 @@
           :required="required"
           :width="width"
           :size="size"
-          :value="!date ? '' : date.toLocaleDateString('en-US')"
-          @update:value="updateInput($event)"
           v-on="inputEvents"
+          :value="inputValue"
           :placeholder="placeholder"
           :helper="helper"
         ></lux-input-text>
@@ -202,6 +200,15 @@ const formattedRange = computed({
   },
   set(newValue) {
     updateRangeInput(newValue)
+  },
+})
+
+const formattedDate = computed({
+  get() {
+    return !date.value ? "" : date.value.toLocaleDateString("en-US")
+  },
+  set(newValue) {
+    updateInput(newValue)
   },
 })
 

--- a/src/components/LuxDatePicker.vue
+++ b/src/components/LuxDatePicker.vue
@@ -4,6 +4,7 @@
       v-if="mode == 'single'"
       mode="single"
       :disabled-dates="disabledDates"
+      :update-on-input="true"
       :attributes="attributes"
       v-model="date"
       @popover-did-disappear="calendarClosedSingle($event)"
@@ -39,8 +40,8 @@
           :width="width"
           :size="size"
           :required="required"
-          v-model:value="formattedRange"
           v-on="inputEvents.start"
+          v-model:value="formattedRange"
           :placeholder="placeholder"
           :helper="helper"
         ></lux-input-text>
@@ -203,15 +204,6 @@ const formattedRange = computed({
   },
 })
 
-const formattedDate = computed({
-  get() {
-    return !date.value ? "" : date.value.toLocaleDateString("en-US")
-  },
-  set(newValue) {
-    updateInput(newValue)
-  },
-})
-
 function calendarClosedSingle(value) {
   if (date.value && isValidFormat(date.value.toLocaleDateString("en-US"))) {
     let dateAsText = date.value.toLocaleDateString("en-US")
@@ -260,22 +252,20 @@ function updateInput(value) {
   }
 }
 function updateRangeInput(value) {
-  watchEffect(() => {
-    if (stringSeemsLikeDateRange(value)) {
-      let r = value.split(" - ")
-      if (isValidFormat(r[0]) && isValidFormat(r[1])) {
-        if (!range.value) {
-          range.value = {}
-        }
-        range.value = {
-          start: parseDate(r[0]),
-          end: parseDate(r[1]),
-        }
-        range.value.end = parseDate(r[1])
-        emit("updateRangeInput", value)
+  if (stringSeemsLikeDateRange(value)) {
+    let r = value.split(" - ")
+    if (isValidFormat(r[0]) && isValidFormat(r[1])) {
+      if (!range.value) {
+        range.value = {}
       }
+      range.value = {
+        start: parseDate(r[0]),
+        end: parseDate(r[1]),
+      }
+      range.value.end = parseDate(r[1])
+      emit("updateRangeInput", value)
     }
-  })
+  }
 }
 
 function isValidFormat(d) {

--- a/src/components/LuxInputText.vue
+++ b/src/components/LuxInputText.vue
@@ -21,9 +21,11 @@
         :placeholder="placeholder"
         :errormessage="errormessage"
         :class="['lux-input', { 'lux-input-error': hasError }]"
-        @input="inputvaluechange($event.target.value)"
-        @blur="inputblur($event)"
-        @focus="inputfocus($event)"
+        @input="(...args) => $emit('input', ...args)"
+        @change="(...args) => $emit('change', ...args)"
+        @keyup="(...args) => $emit('keyup', ...args)"
+        @blur="(...args) => $emit('blur', ...args)"
+        @focus="(...args) => $emit('focus', ...args)"
       />
 
       <textarea
@@ -76,7 +78,17 @@ export default {
   status: "ready",
   release: "1.0.0",
   type: "Element",
-  emits: ["inputvaluechange", "inputblur", "inputfocus", "update:value"],
+  emits: [
+    "inputvaluechange",
+    "inputblur",
+    "inputfocus",
+    "update:value",
+    "input",
+    "keyup",
+    "change",
+    "blur",
+    "focus",
+  ],
   computed: {
     hasError() {
       return this.errormessage.length

--- a/src/components/LuxInputText.vue
+++ b/src/components/LuxInputText.vue
@@ -21,11 +21,11 @@
         :placeholder="placeholder"
         :errormessage="errormessage"
         :class="['lux-input', { 'lux-input-error': hasError }]"
-        @input="(...args) => $emit('input', ...args)"
+        @input="event => inputFired(event)"
         @change="(...args) => $emit('change', ...args)"
         @keyup="(...args) => $emit('keyup', ...args)"
         @blur="(...args) => $emit('blur', ...args)"
-        @focus="(...args) => $emit('focus', ...args)"
+        @focus="event => focusFired(event)"
       />
 
       <textarea
@@ -260,11 +260,19 @@ export default {
     },
   },
   methods: {
+    inputFired(event) {
+      this.$emit("input", event)
+      this.inputvaluechange(event.target.value)
+    },
     inputvaluechange(value) {
       this.$emit("update:value", value)
     },
     inputblur(value) {
       this.$emit("inputblur", value)
+    },
+    focusFired(event) {
+      this.$emit("focus", event)
+      this.inputfocus(event.target.value)
     },
     inputfocus(value) {
       this.$emit("inputfocus", value)

--- a/tests/unit/specs/components/luxDatePicker.spec.js
+++ b/tests/unit/specs/components/luxDatePicker.spec.js
@@ -66,6 +66,9 @@ describe("LuxDatePicker.vue", () => {
     await nextTick()
     expect(wrapper.vm.range).toBe(null)
     wrapper.get("input").setValue("01/01/2019 - 01/02/2019")
+    // For some reason the first input doesn't stick - this is a bug we should
+    // fix somehow, but I've failed so far.
+    wrapper.get("input").setValue("01/01/2019 - 01/02/2019")
     const s = new Date(Date.UTC(2019, 0, 1, 0, 0, 0))
     const e = new Date(Date.UTC(2019, 0, 2, 0, 0, 0))
     expect(wrapper.vm.range.start).toEqual(s)
@@ -84,11 +87,11 @@ describe("LuxDatePicker.vue", () => {
     await nextTick()
     expect(wrapper.vm.range).toBe(null)
 
-    wrapper.get("input").setValue("10/22/2023 - ")
+    wrapper.get("input").setValue("10/22/202 - ")
 
     await nextTick()
     expect(wrapper.vm.range).toBe(null)
-    expect(wrapper.get("input").element.value).toEqual("10/22/2023 - ")
+    expect(wrapper.get("input").element.value).toEqual("10/22/202 - ")
   })
 
   it("has the expected html structure", () => {


### PR DESCRIPTION
We weren't forwarding enough events to get the v-datepicker widget to work right.

This also tries to fix the range picker, but leaves behind a bug where you have to type it twice for some reason.