### PR TITLE
Adds emits to radio and checkbox components

### DIFF
--- a/src/components/LuxInputCheckbox.vue
+++ b/src/components/LuxInputCheckbox.vue
@@ -39,6 +39,7 @@ export default {
     prop: "checked",
     event: "change",
   },
+  emits: ["change", "inputblur"],
   data: function () {
     return {
       wrapper: this.groupLabel.length ? "fieldset" : "div",

--- a/src/components/LuxInputRadio.vue
+++ b/src/components/LuxInputRadio.vue
@@ -35,6 +35,11 @@ export default {
   status: "ready",
   release: "1.0.0",
   type: "Element",
+  model: {
+    prop: "checked",
+    event: "change",
+  },
+  emits: ["change", "inputblur"],
   data: function () {
     return {
       wrapper: this.groupLabel.length ? "fieldset" : "div",


### PR DESCRIPTION
This update will make sure emits are registered for these components and will fix the radio button behavior found in the Order Manager. Blocking the Figgy LUX/Vue3 upgrade.