### PR TITLE
[LuxLibraryHeader] locally register child components

### DIFF
--- a/src/components/LuxLibraryHeader.vue
+++ b/src/components/LuxLibraryHeader.vue
@@ -13,6 +13,10 @@
 </template>
 
 <script>
+import LuxLibraryLogo from "./LuxLibraryLogo.vue"
+import LuxSpacer from "./LuxSpacer.vue"
+import LuxWrapper from "./LuxWrapper.vue"
+
 /**
  * LibraryHeader is the preferred Header styling/behavior for PUL websites.
  * Don't forget to create a fallback for this component by also providing the HTML
@@ -71,6 +75,11 @@ export default {
     value: function (theme) {
       return theme == "light" ? "light" : "dark"
     },
+  },
+  components: {
+    LuxSpacer,
+    LuxWrapper,
+    LuxLibraryLogo,
   },
 }
 </script>

--- a/src/components/LuxLibraryLogo.vue
+++ b/src/components/LuxLibraryLogo.vue
@@ -9,6 +9,9 @@
 </template>
 
 <script>
+import LuxLogoLibrary from "./logos/LuxLogoLibrary.vue"
+import LuxLogoLibraryIcon from "./logos/LuxLogoLibraryIcon.vue"
+
 /**
  * Used to identify that the site is a Princeton University site in the footer
  * and links to princeton.edu.
@@ -33,6 +36,10 @@ export default {
       type: String,
       default: "dark",
     },
+  },
+  components: {
+    LuxLogoLibrary,
+    LuxLogoLibraryIcon,
   },
 }
 </script>


### PR DESCRIPTION
This allows lux applications to simply import LuxLibraryHeader into a component, and it displays completely, without missing logos or spacers.  This means that lux applications don't have to import all of lux, and can instead tree-shake it for a smaller bundle size.

See https://vuejs.org/guide/components/registration.html#local-registration for more details on local registration.

Closes #217
Helps with pulibrary/static-tables#125