### PR TITLE
[#233]Add media query for screens less than 899px to handle the abbr-name in the LibraryHeader

### DIFF
--- a/src/components/LuxLibraryHeader.vue
+++ b/src/components/LuxLibraryHeader.vue
@@ -183,6 +183,17 @@ export default {
       display: none;
     }
   }
+
+  @media (max-width: 899px) {
+    .full-name {
+      display: none;
+    }
+
+    .abbr-name {
+      display: block;
+      font-size: var(--font-size-small);
+    }
+  }
 }
 </style>
 


### PR DESCRIPTION
closes #233 