### PR TITLE
[#168] recolor logo

### DIFF
--- a/src/components/LuxLibraryLogo.vue
+++ b/src/components/LuxLibraryLogo.vue
@@ -3,7 +3,14 @@
     <a href="https://library.princeton.edu">
       <lux-logo-library width="155px" height="34px" v-if="theme === 'dark'" class="full-logo" />
       <lux-logo-library width="155px" height="34px" v-else color="#000000" class="full-logo" />
-      <lux-logo-library-icon width="34px" height="34px" class="icon-only" />
+      <lux-logo-library-icon width="34px" height="34px" v-if="theme === 'dark'" class="icon-only" />
+      <lux-logo-library-icon
+        width="34px"
+        height="34px"
+        v-else
+        color="var(--color-princeton-orange-on-white)"
+        class="icon-only"
+      />
     </a>
   </component>
 </template>
@@ -73,7 +80,7 @@ export default {
 <docs>
   ```jsx
     <div>
-      <lux-library-logo></lux-library-logo>
+      <lux-library-logo theme="light"></lux-library-logo>
     </div>
   ```
 </docs>

--- a/src/components/logos/LuxLogoLibraryIcon.vue
+++ b/src/components/logos/LuxLogoLibraryIcon.vue
@@ -12,7 +12,7 @@
     <g>
       <path
         d="M12.2 0h71.5A12.27 12.27 0 0196 12.2v72.5A12.29 12.29 0 0183.7 97H12.2A12.27 12.27 0 010 84.7V12.2A12.25 12.25 0 0112.2 0z"
-        fill="#ef7622"
+        :style="{ fill: color }"
       />
       <path
         class="cls-2"
@@ -49,6 +49,10 @@ export default {
     height: {
       type: [Number, String],
       default: 97,
+    },
+    color: {
+      type: String,
+      default: "var(--color-princeton-orange-on-black)",
     },
   },
 }


### PR DESCRIPTION
Closes #168 

We changed the princeton logo color based on light or dark theme. We added the dark theme color "var(--color-princeton-orange-on-black)" as default.