### PR TITLE
[LuxInputButton] #185 remove $color-bleu-de-france-darker; 

### DIFF
--- a/src/components/LuxInputButton.vue
+++ b/src/components/LuxInputButton.vue
@@ -208,7 +208,6 @@ export default {
     border: 2px solid $color-bleu-de-france;
     &:hover,
     &:focus {
-      color: $color-bleu-de-france-darker;
       border-color: $color-bleu-de-france-darker;
     }
   }


### PR DESCRIPTION
part of #185
It helps with Subscribe button on focus in LuxLibraryFooter not to change color to blue