### PR TITLE
[LuxLibraryFooter][LuxLibraryHeader] Display the Library Logo and 'Princeton University Library' across all screens

### DIFF
--- a/src/components/LuxLibraryLogo.vue
+++ b/src/components/LuxLibraryLogo.vue
@@ -3,21 +3,12 @@
     <a href="https://library.princeton.edu">
       <lux-logo-library width="155px" height="34px" v-if="theme === 'dark'" class="full-logo" />
       <lux-logo-library width="155px" height="34px" v-else color="#000000" class="full-logo" />
-      <lux-logo-library-icon width="34px" height="34px" v-if="theme === 'dark'" class="icon-only" />
-      <lux-logo-library-icon
-        width="34px"
-        height="34px"
-        v-else
-        color="var(--color-princeton-orange-on-white)"
-        class="icon-only"
-      />
     </a>
   </component>
 </template>
 
 <script>
 import LuxLogoLibrary from "./logos/LuxLogoLibrary.vue"
-import LuxLogoLibraryIcon from "./logos/LuxLogoLibraryIcon.vue"
 
 /**
  * Used to identify that the site is a Princeton University site in the footer
@@ -46,7 +37,6 @@ export default {
   },
   components: {
     LuxLogoLibrary,
-    LuxLogoLibraryIcon,
   },
 }
 </script>
@@ -60,20 +50,7 @@ export default {
 }
 
 .full-logo {
-  display: none;
-}
-
-.icon-only {
   display: block;
-}
-
-@media #{$media-query-x-large} {
-  .icon-only {
-    display: none;
-  }
-  .full-logo {
-    display: block;
-  }
 }
 </style>
 

--- a/tests/unit/specs/components/luxLibraryHeader.spec.js
+++ b/tests/unit/specs/components/luxLibraryHeader.spec.js
@@ -24,7 +24,7 @@ describe("LuxLibraryHeader.vue", () => {
   })
   it("accepts a type prop", () => {
     expect(wrapper.find("abbr").text()).toBe(
-      "Princeton University LibraryPrinceton University LibraryMy ApplicationMy AppSome menu bar"
+      "Princeton University LibraryMy ApplicationMy AppSome menu bar"
     )
   })
   it("gets the theme and defaults to dark unless the theme is light", () => {


### PR DESCRIPTION
closes #262

part of #https://github.com/pulibrary/allsearch_frontend/issues/313