### PR TITLE
Use gray-100, rather than rich black, as the background color in header and footer

### DIFF
--- a/src/assets/styles/variables.css
+++ b/src/assets/styles/variables.css
@@ -31,6 +31,7 @@
   --color-princeton-orange-on-black: rgb(245, 128, 37);
   --color-princeton-orange-50: #E77500;
   --color-princeton-orange-10: #FCF1E5;
+  --color-gray-100: #121212;
   --font-size-large-min: 1.125em;
   --font-size-base-max: 1.125em;
   --font-size-x-large: 36px;

--- a/src/components/LuxLibraryFooter.vue
+++ b/src/components/LuxLibraryFooter.vue
@@ -161,7 +161,7 @@ export default {
   font-family: var(--font-family-heading);
   line-height: var(--line-height-heading);
   color: var(--color-white);
-  background: var(--color-rich-black);
+  background: var(--color-gray-100);
   padding-top: 1em;
   padding-bottom: 1em;
   margin-top: 3em;

--- a/src/components/LuxLibraryHeader.vue
+++ b/src/components/LuxLibraryHeader.vue
@@ -121,7 +121,7 @@ export default {
   }
 
   &.dark {
-    background: var(--color-rich-black);
+    background: var(--color-gray-100);
   }
 
   &.shade {

--- a/src/components/LuxMenuBar.vue
+++ b/src/components/LuxMenuBar.vue
@@ -586,7 +586,7 @@ export default {
 }
 
 .dark {
-  background: var(--color-rich-black);
+  background: var(--color-gray-100);
 
   @media (max-width: 899px) {
     &.lux-main-menu a {
@@ -651,7 +651,7 @@ export default {
   :deep(.hamburger-inner),
   :deep(.hamburger-inner:after),
   :deep(.hamburger-inner:before) {
-    background-color: var(--color-rich-black);
+    background-color: var(--color-gray-100);
   }
 
   @media (max-width: 899px) {

--- a/src/components/_LuxLibraryContactInfo.vue
+++ b/src/components/_LuxLibraryContactInfo.vue
@@ -54,7 +54,7 @@ export default {
 
   &.dark {
     color: var(--color-white);
-    background-color: var(--color-rich-black);
+    background-color: var(--color-gray-100);
     a {
       color: var(--color-white);
     }

--- a/src/components/_LuxUniversityAccessibility.vue
+++ b/src/components/_LuxUniversityAccessibility.vue
@@ -55,7 +55,7 @@ export default {
   &.dark {
     a {
       color: var(--color-white);
-      background: var(--color-rich-black);
+      background: var(--color-gray-100);
     }
   }
 

--- a/src/components/_LuxUniversityCopyright.vue
+++ b/src/components/_LuxUniversityCopyright.vue
@@ -45,7 +45,7 @@ export default {
 
   &.dark {
     color: var(--color-white);
-    background: var(--color-rich-black);
+    background: var(--color-gray-100);
   }
   &.shade {
     color: var(--color-white);


### PR DESCRIPTION
This makes it consistent with the new WDS website look

closes #266 