### PR TITLE
[LuxLibraryFooter] Accessibility link and copyright should have same font size as the rest of the footer

### DIFF
--- a/src/components/_LuxUniversityAccessibility.vue
+++ b/src/components/_LuxUniversityAccessibility.vue
@@ -40,7 +40,7 @@ export default {
   @include reset;
   @include stack-space(var(--space-base));
   font-family: var(--font-family-heading);
-  font-size: var(--font-size-x-small);
+  font-size: var(--font-size-small);
   line-height: var(--line-height-heading);
 
   a {

--- a/src/components/_LuxUniversityCopyright.vue
+++ b/src/components/_LuxUniversityCopyright.vue
@@ -40,7 +40,7 @@ export default {
   @include reset;
   @include stack-space(var(--space-xx-small));
   font-family: var(--font-family-heading);
-  font-size: var(--font-size-x-small);
+  font-size: var(--font-size-small);
   line-height: var(--line-height-heading);
 
   &.dark {


### PR DESCRIPTION
helps with #267 