### PR TITLE
[LuxSubscribeNewsletter] Use label and hideLabel props to provide an accessible name for the input

### DIFF
--- a/src/components/_LuxSubscribeNewsletter.vue
+++ b/src/components/_LuxSubscribeNewsletter.vue
@@ -15,7 +15,8 @@
           type="email"
           name="EMAIL"
           aria-required="true"
-          aria-label="Email address"
+          label="Email address"
+          hideLabel="true"
         />
         <lux-input-button
           id="mc-embedded-subscribe"


### PR DESCRIPTION
Previously, we were using aria-label, but the LuxInputText component doesn't have an aria-label prop, so it was not being properly associated with the input