### PR TITLE
[LuxSubscribeNewsletter] Don't add aria-required to input

### DIFF
--- a/src/components/_LuxSubscribeNewsletter.vue
+++ b/src/components/_LuxSubscribeNewsletter.vue
@@ -14,7 +14,6 @@
           id="mce-EMAIL"
           type="email"
           name="EMAIL"
-          aria-required="true"
           label="Email address"
           hideLabel="true"
         />


### PR DESCRIPTION
LuxInputText doesn't have a prop for aria-required, so it was not getting attached to the input anyway.  Also, the input isn't really required; the form works okay whether you enter your email address or not, so we don't need to tell screen reader users that the field is required.