### PR TITLE
[luxUniversityAccessibility] show that the link opens in a new tab

### DIFF
--- a/src/components/LuxHyperlink.vue
+++ b/src/components/LuxHyperlink.vue
@@ -1,10 +1,16 @@
 <template>
-  <a :href="href" :class="['lux-link', variation, size]">
+  <a :href="href" :class="['lux-link', variation, size]" :target="newTab ? '_blank' : null">
     <slot />
+    <lux-icon-base v-if="newTab" width="14" height="14" icon-name="(opens in new tab)">
+      <lux-icon-new-tab></lux-icon-new-tab>
+    </lux-icon-base>
   </a>
 </template>
 
 <script>
+import LuxIconBase from "./icons/LuxIconBase.vue"
+import LuxIconNewTab from "./icons/LuxIconNewTab.vue"
+
 /**
  * Used to create hyperlinks as text or buttons. Can also be used on Card component
  * sub-elements to make the entire card click-able.
@@ -44,6 +50,18 @@ export default {
         return value.match(/(small|medium|large)/)
       },
     },
+    /**
+     * Should the link open in a new tab?  This can be
+     * disconcerting, so don't use it unless necessary.
+     */
+    newTab: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  components: {
+    LuxIconBase,
+    LuxIconNewTab,
   },
 }
 </script>
@@ -137,6 +155,7 @@ export default {
       <lux-hyperlink href="#" variation="button solid">Bar</lux-hyperlink>
       <lux-hyperlink href="#" variation="button solid" size="large">Bar</lux-hyperlink>
       <lux-hyperlink href="#" variation="button outline">Bar</lux-hyperlink>
+      <lux-hyperlink href="#" newTab="true">I open in a new tab</lux-hyperlink>
     </div>
   ```
 </docs>

--- a/src/components/_LuxUniversityAccessibility.vue
+++ b/src/components/_LuxUniversityAccessibility.vue
@@ -1,10 +1,14 @@
 <template>
   <component :is="type" :class="['lux-accessibility', theme]">
-    <a href="https://accessibility.princeton.edu/help">Accessibility Help</a>
+    <LuxHyperlink href="https://accessibility.princeton.edu/help" newTab="true"
+      >Accessibility Help</LuxHyperlink
+    >
   </component>
 </template>
 
 <script>
+import LuxHyperlink from "./LuxHyperlink.vue"
+
 /**
  * Used to show the University’s Accessibility site in the footer.
  */
@@ -26,6 +30,9 @@ export default {
       type: String,
       default: "dark",
     },
+  },
+  components: {
+    LuxHyperlink,
   },
 }
 </script>

--- a/src/components/icons/LuxIconNewTab.vue
+++ b/src/components/icons/LuxIconNewTab.vue
@@ -1,0 +1,47 @@
+<template>
+  <g>
+    <path
+      class="cls-2"
+      d="M12.5,13c.3,0,.5-.1.7-.3l5.8-6.2v2.5c0,.6.4,1,1,1s1-.4,1-1V4s0,0,0,0c0-.6-.5-1-1-1h-4.5c-.6,0-1,.4-1,1s.4,1,1,1h2.2l-5.9,6.3c-.4.4-.4,1,0,1.4.2.2.4.3.7.3h0Z"
+    />
+    <rect class="cls-2" x="1.4" y="5.9" width="11.2" height="2" />
+    <rect class="cls-2" x="1.4" y="20.2" width="17.9" height="2" />
+    <rect class="cls-2" x="17.3" y="12.1" width="2" height="8.1" />
+    <rect class="cls-2" x="1.4" y="7.9" width="2" height="12.3" />
+  </g>
+</template>
+
+<script>
+/**
+ * Icons are used to visually communicate core parts of the product and
+ * available actions. Please be aware that all elements must have closing tags (not "self-closing").
+ * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
+ */
+export default {
+  name: "LuxIconNewTab",
+  status: "ready",
+  release: "1.0.0",
+  type: "Element",
+}
+</script>
+
+<docs>
+  ```jsx
+  <div>
+    <!-- you can pass in a smaller `width` and `height` as props -->
+    <lux-icon-base width="12" height="12" icon-name="Add Item">
+      <lux-icon-new-tab></lux-icon-new-tab>
+    </lux-icon-base>
+
+    <!-- or you can use the default, which is 18 -->
+    <lux-icon-base icon-name="Add Item">
+      <lux-icon-new-tab></lux-icon-new-tab>
+    </lux-icon-base>
+
+    <!-- or make it a little bigger too, with colors :) -->
+    <lux-icon-base width="30" height="30" icon-name="Add Item" icon-color="red">
+      <lux-icon-new-tab></lux-icon-new-tab>
+    </lux-icon-base>
+  </div>
+  ```
+</docs>

--- a/src/components/icons/index.js
+++ b/src/components/icons/index.js
@@ -25,6 +25,7 @@ import LuxIconHospital from "./LuxIconHospital.vue"
 import LuxIconInfo from "./LuxIconInfo.vue"
 import LuxIconLockClose from "./LuxIconLockClose.vue"
 import LuxIconLockOpen from "./LuxIconLockOpen.vue"
+import LuxIconNewTab from "./LuxIconNewTab.vue"
 import LuxIconNote from "./LuxIconNote.vue"
 import LuxIconPerson from "./LuxIconPerson.vue"
 import LuxIconPicture from "./LuxIconPicture.vue"
@@ -72,6 +73,7 @@ export {
   LuxIconInfo,
   LuxIconLockClose,
   LuxIconLockOpen,
+  LuxIconNewTab,
   LuxIconNote,
   LuxIconPerson,
   LuxIconPicture,

--- a/tests/unit/specs/components/__snapshots__/luxDataTable.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/luxDataTable.spec.js.snap
@@ -235,6 +235,7 @@ exports[`LuxDataTable.vue has the expected html structure 1`] = `
             
             foo
             
+            <!--v-if-->
           </a>
         </span>
       </td>

--- a/tests/unit/specs/components/__snapshots__/luxHyperlink.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/luxHyperlink.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Hyperlink.vue has the expected html structure 1`] = `
+exports[`LuxHyperlink.vue has the expected html structure 1`] = `
 <a
   class="lux-link link medium"
   href="https://library.princeton.edu"
@@ -8,5 +8,6 @@ exports[`Hyperlink.vue has the expected html structure 1`] = `
   
   I'll take you places
   
+  <!--v-if-->
 </a>
 `;

--- a/tests/unit/specs/components/luxHyperlink.spec.js
+++ b/tests/unit/specs/components/luxHyperlink.spec.js
@@ -2,7 +2,7 @@ import { mount } from "@vue/test-utils"
 import LuxHyperlink from "@/components/LuxHyperlink.vue"
 import { nextTick } from "vue"
 
-describe("Hyperlink.vue", () => {
+describe("LuxHyperlink.vue", () => {
   let wrapper
 
   beforeEach(() => {
@@ -27,6 +27,34 @@ describe("Hyperlink.vue", () => {
     await nextTick()
     const link = wrapper.find("a")
     expect(link.classes()).toContain("button")
+  })
+
+  it("does not have a target attribute by default", () => {
+    expect(wrapper.find("a").attributes("target")).toBeUndefined()
+  })
+
+  it("does not have an icon by default", () => {
+    expect(wrapper.find("a").find("svg").exists()).toBe(false)
+  })
+
+  describe("with the newTab prop", () => {
+    beforeEach(async () => {
+      wrapper.setProps({ newTab: true })
+      await nextTick()
+    })
+
+    it("adds target _blank", () => {
+      expect(wrapper.find("a").attributes("target")).toEqual("_blank")
+    })
+
+    it("adds an icon", () => {
+      const link = wrapper.find("a")
+      expect(link.find("svg").exists()).toBe(true)
+    })
+
+    it("tells screen readers that the link opens in a new tab", () => {
+      expect(wrapper.find("a").text()).toContain("opens in new tab")
+    })
   })
 
   it("has the expected html structure", () => {

--- a/tests/unit/specs/components/luxUniversityAccessibility.js
+++ b/tests/unit/specs/components/luxUniversityAccessibility.js
@@ -1,0 +1,9 @@
+import { mount } from "@vue/test-utils"
+import _LuxUniversityAccessibility from "@/components/_LuxUniversityAccessibility.vue"
+
+describe("LuxUniversityAccessibility component", () => {
+  it("tells screen reader users that it opens in a new tab", () => {
+    const wrapper = mount(_LuxUniversityAccessibility)
+    expect(wrapper.text()).toContain("opens in new tab")
+  })
+})


### PR DESCRIPTION
This also adds an SVG icon for opening in a new tab, and adds a prop to LuxHyperlink to toggle the icon on or off.  When the SVG icon is shown, its accessible name is set to 'opens in new tab', to let screen reader users also know about it.

Closes #265