### PR TITLE
[#288] reduce console warnings

### DIFF
--- a/src/components/LuxHyperlink.vue
+++ b/src/components/LuxHyperlink.vue
@@ -155,7 +155,7 @@ export default {
       <lux-hyperlink href="#" variation="button solid">Bar</lux-hyperlink>
       <lux-hyperlink href="#" variation="button solid" size="large">Bar</lux-hyperlink>
       <lux-hyperlink href="#" variation="button outline">Bar</lux-hyperlink>
-      <lux-hyperlink href="#" newTab="true">I open in a new tab</lux-hyperlink>
+      <lux-hyperlink href="#" :newTab="true">I open in a new tab</lux-hyperlink>
     </div>
   ```
 </docs>

--- a/src/components/LuxInputButton.vue
+++ b/src/components/LuxInputButton.vue
@@ -21,6 +21,8 @@
 </template>
 
 <script>
+import LuxIconBase from "./icons/LuxIconBase.vue"
+
 /**
  * Buttons are used to toggle something in the interface or trigger new
  * content in the same context.
@@ -140,6 +142,9 @@ export default {
         this.$refs.inputButton.focus()
       }
     })
+  },
+  components: {
+    LuxIconBase,
   },
 }
 </script>

--- a/src/components/LuxInputText.vue
+++ b/src/components/LuxInputText.vue
@@ -68,6 +68,11 @@
 </template>
 
 <script>
+import LuxIconAlert from "./icons/LuxIconAlert.vue"
+import LuxIconApproved from "./icons/LuxIconApproved.vue"
+import LuxIconBase from "./icons/LuxIconBase.vue"
+import LuxIconDenied from "./icons/LuxIconDenied.vue"
+
 /**
  * Form Inputs are used to allow users to provide text input when the expected
  * input is short. Form Input has a range of options and supports several text
@@ -291,6 +296,12 @@ export default {
         }
       }
     })
+  },
+  components: {
+    LuxIconAlert,
+    LuxIconApproved,
+    LuxIconDenied,
+    LuxIconBase,
   },
 }
 </script>

--- a/src/components/LuxLibraryFooter.vue
+++ b/src/components/LuxLibraryFooter.vue
@@ -10,7 +10,7 @@
         </div>
         <div class="lux-library-links subscribe-layout">
           <h2>Subscribe to our Newsletter</h2>
-          <lux-subscribe-newsletter type="div" :theme="value(theme)" />
+          <lux-subscribe-newsletter type="div" />
           <div class="social-pul-icons">
             <a href="https://x.com/PULibrary"><lux-logo-x width="24" height="24" /></a>
             <a href="http://www.facebook.com/PULibrary"

--- a/src/components/_LuxSubscribeNewsletter.vue
+++ b/src/components/_LuxSubscribeNewsletter.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="type" :class="['lux-subscribe-newsletter', theme]">
+  <component :is="type" class="lux-subscribe-newsletter">
     <form
       id="mc-embedded-subscribe-form"
       action="https://princeton.us4.list-manage.com/subscribe/post?u=f1159e2c2a8bc35d62147f282&amp;id=6c19fe9a37"
@@ -15,7 +15,7 @@
           type="email"
           name="EMAIL"
           label="Email address"
-          hideLabel="true"
+          :hideLabel="true"
         />
         <lux-input-button
           id="mc-embedded-subscribe"
@@ -23,7 +23,6 @@
           name="subscribe"
           class="lux-subscribe-newsletter"
           variation="outline"
-          :size="size"
           aria-describedby="describe-mailchimp-form"
           >{{ buttonLabel }}</lux-input-button
         >
@@ -112,7 +111,7 @@ export default {
 <docs>
   ```jsx
   <div>
-    <lux-subscribe-newsletter theme="light" type="div"></lux-subscribe-newsletter>
+    <lux-subscribe-newsletter type="div"></lux-subscribe-newsletter>
   </div>
   ```
 </docs>

--- a/src/components/_LuxUniversityAccessibility.vue
+++ b/src/components/_LuxUniversityAccessibility.vue
@@ -1,6 +1,6 @@
 <template>
   <component :is="type" :class="['lux-accessibility', theme]">
-    <LuxHyperlink href="https://accessibility.princeton.edu/help" newTab="true"
+    <LuxHyperlink href="https://accessibility.princeton.edu/help" :newTab="true"
       >Accessibility Help</LuxHyperlink
     >
   </component>


### PR DESCRIPTION
* Pass boolean true to boolean props, rather than the string true
* Locally register component dependencies, for applications that only use a few lux components and want to tree-shake (e.g. allsearch-frontend)
* Remove some undefined variables/unused props


closes #288 