### PR TITLE
[LuxLibraryHeader] use the same amount of padding as LuxLibraryFooter

### DIFF
--- a/src/components/LuxLibraryHeader.vue
+++ b/src/components/LuxLibraryHeader.vue
@@ -171,7 +171,7 @@ export default {
 .lux-header-content {
   align-items: center;
   display: flex;
-  padding: 0 var(--space-small);
+  padding: 0 1rem;
 
   @media (min-width: 900px) {
     flex-direction: row;


### PR DESCRIPTION
This allows the logos in the header and footer to be aligned horizontally. Helps with pulibrary/allsearch_frontend#316