### PR TITLE
[LuxLibraryFooter] Remove margin-top from footer. 

### DIFF
--- a/src/components/LuxLibraryFooter.vue
+++ b/src/components/LuxLibraryFooter.vue
@@ -186,7 +186,6 @@ export default {
   background: var(--color-gray-100);
   padding-top: 1em;
   padding-bottom: 1em;
-  margin-top: 3em;
 
   &.dark {
     .lux-library-links a {


### PR DESCRIPTION
Let the application main section to handle the margin-bottom.