### PR TITLE
Updates Lux library footer and LuxLogoUniversityWhite

### DIFF
--- a/src/assets/styles/system.scss
+++ b/src/assets/styles/system.scss
@@ -76,7 +76,7 @@ $space-x-small: 8px;
 $space-xx-small: 4px;
 $line-height-base: 1.6;
 $line-height-small: 1.3;
-$line-height-heading: 1;
+$line-height-heading: 1.5;
 
 /* GLOBAL MIXINS
 --------------------------------------------- */

--- a/src/assets/styles/variables.css
+++ b/src/assets/styles/variables.css
@@ -95,6 +95,6 @@
   --space-xx-small: 4px;
   --line-height-base: 1.6;
   --line-height-small: 1.175;
-  --line-height-heading: 1;
+  --line-height-heading: 1.5;
   --positive-text: #7cb518;
 }

--- a/src/components/LuxLibraryFooter.vue
+++ b/src/components/LuxLibraryFooter.vue
@@ -155,9 +155,6 @@ export default {
   border-top: 1px solid rgba(255, 255, 255, 0.3);
 }
 
-.lux-library-logo {
-  padding-bottom: 2rem;
-}
 .lux-logo-x {
   margin: 0.5rem 0.1rem 0rem 0.2rem;
 }
@@ -185,7 +182,6 @@ export default {
   color: var(--color-white);
   background: var(--color-gray-100);
   padding-top: 1em;
-  padding-bottom: 1em;
 
   &.dark {
     .lux-library-links a {
@@ -271,7 +267,7 @@ export default {
   flex-flow: column wrap;
   align-self: auto;
   justify-content: center;
-  padding-bottom: 1em;
+  //padding-bottom: 1em;
   @media (min-width: 900px) {
     flex: 1;
   }
@@ -311,8 +307,8 @@ export default {
     }
 
     li {
-      line-height: var(--line-height-base);
-      font-size: var(--font-size-small);
+      line-height: var(--line-height-heading);
+      font-size: var(--font-size-base);
     }
   }
 }

--- a/src/components/LuxLibraryFooter.vue
+++ b/src/components/LuxLibraryFooter.vue
@@ -44,7 +44,7 @@
         </div>
         <div class="lux-library-links pu-logo-white">
           <a href="https://www.princeton.edu"
-            ><lux-logo-university-white width="200px" height="80px" type="div"
+            ><lux-logo-university-white width="200px" height="72px" type="div"
           /></a>
         </div>
       </div>
@@ -239,7 +239,6 @@ export default {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  padding: 1rem 0rem;
 
   @media (min-width: 900px) {
     max-width: 1440px;
@@ -267,7 +266,6 @@ export default {
   flex-flow: column wrap;
   align-self: auto;
   justify-content: center;
-  //padding-bottom: 1em;
   @media (min-width: 900px) {
     flex: 1;
   }

--- a/src/components/_LuxLibraryContactInfo.vue
+++ b/src/components/_LuxLibraryContactInfo.vue
@@ -50,7 +50,7 @@ export default {
   @include reset;
   @include stack-space(var(--space-x-small));
   font-family: var(--font-family-heading);
-  font-size: var(--font-size-small);
+  font-size: var(--font-size-base);
   line-height: var(--line-height-base);
 
   &.dark {

--- a/src/components/_LuxLibraryContactInfoOld.vue
+++ b/src/components/_LuxLibraryContactInfoOld.vue
@@ -71,7 +71,7 @@ export default {
   @include reset;
   @include stack-space(var(--space-x-small));
   font-family: var(--font-family-heading);
-  font-size: var(--font-size-small);
+  font-size: var(--font-size-base);
   line-height: var(--line-height-base);
   color: var(--color-rich-black);
 

--- a/src/components/_LuxUniversityAccessibility.vue
+++ b/src/components/_LuxUniversityAccessibility.vue
@@ -48,7 +48,7 @@ export default {
   @include reset;
   @include stack-space(var(--space-base));
   font-family: var(--font-family-heading);
-  font-size: var(--font-size-small);
+  font-size: var(--font-size-base);
   line-height: var(--line-height-heading);
 
   a {

--- a/src/components/_LuxUniversityCopyright.vue
+++ b/src/components/_LuxUniversityCopyright.vue
@@ -40,7 +40,7 @@ export default {
   @include reset;
   @include stack-space(var(--space-xx-small));
   font-family: var(--font-family-heading);
-  font-size: var(--font-size-small);
+  font-size: var(--font-size-base);
   line-height: var(--line-height-heading);
 
   &.dark {

--- a/src/components/logos/LuxLogoUniversityWhite.vue
+++ b/src/components/logos/LuxLogoUniversityWhite.vue
@@ -3,7 +3,7 @@
     xmlns="http://www.w3.org/2000/svg"
     :width="width"
     :height="height"
-    viewBox="0 0 263 71.84"
+    viewBox="0 0 194 54.892"
     aria-labelledby="logo-university-white"
     role="img"
   >


### PR DESCRIPTION
Update footer to use font-size-base
Update line-height-heading to 1.5
Remove bottom footer padding
Remove pul-logo bottom footer padding
part of https://github.com/pulibrary/lux-design-system/issues/305 part of https://github.com/pulibrary/lux-design-system/issues/306 
part of https://github.com/pulibrary/lux-design-system/issues/309

Update viewport
Update height of LuxLogoUniversityWhite
closes https://github.com/pulibrary/lux-design-system/issues/309