### PR TITLE
Don't show an orange border on hover

### DIFF
--- a/src/assets/styles/focus.scss
+++ b/src/assets/styles/focus.scss
@@ -1,13 +1,26 @@
 /* VUE DESIGN SYSTEM FOCUS AND HOVER HELPERS
 --------------------------------------------- */
-@mixin princeton-focus($theme: light) {
+@function decoration-color-by-theme($theme: light) {
   @if $theme == light {
-    outline: var(--color-princeton-orange-on-white) solid 0.25rem;
+    @return var(--color-princeton-orange-on-white);
   } @else if $theme == dark {
-    outline: var(--color-princeton-orange-on-black) solid 0.25rem;
+    @return var(--color-princeton-orange-on-black);
   } @else if $theme == shade {
-    outline: var(--color-princeton-orange-on-black) solid 0.25rem;
+    @return var(--color-princeton-orange-on-black);
   }
-  outline-offset: none;
-  box-shadow: none;
+}
+@mixin princeton-focus($theme: light) {
+  &:hover {
+    text-decoration: underline;
+    text-decoration-color: decoration-color-by-theme($theme)
+  }
+  &:focus-visible {
+    outline: decoration-color-by-theme($theme) solid 0.25rem;
+    outline-offset: none;
+    box-shadow: none;
+  }
+  &:focus-within {
+    text-decoration: underline;
+    text-decoration-color: decoration-color-by-theme($theme)
+  }
 }

--- a/src/components/LuxCard.vue
+++ b/src/components/LuxCard.vue
@@ -193,12 +193,7 @@ export default {
     background-color: rgba(0, 0, 0, 0);
   }
 
-  &:hover,
-  &:focus-visible {
-    &::after {
-      @include princeton-focus(light);
-    }
-  }
+  @include princeton-focus(light);
 
   &:visited {
     color: var(--color-rich-black);

--- a/src/components/LuxInputButton.vue
+++ b/src/components/LuxInputButton.vue
@@ -198,19 +198,16 @@ export default {
   &.icon-prepend {
     display: flex;
     align-items: center;
-    &:hover,
-    &:focus-visible {
-      @include princeton-focus(light);
-    }
+    @include princeton-focus(light);
   }
 
   &.solid {
     background: $color-bleu-de-france;
     color: $color-white;
+    @include princeton-focus(light);
     &:hover,
     &:focus-visible {
       background: $color-bleu-de-france-darker;
-      @include princeton-focus(light);
     }
   }
 
@@ -227,10 +224,7 @@ export default {
 
   &.text {
     background-color: transparent;
-    &:hover,
-    &:focus-visible {
-      @include princeton-focus(light);
-    }
+    @include princeton-focus(light);
   }
 
   &.dropdown {

--- a/src/components/LuxInputText.vue
+++ b/src/components/LuxInputText.vue
@@ -388,10 +388,7 @@ $color-placeholder: tint(rgb(149, 156, 167), 50%);
         -moz-osx-font-smoothing: grayscale;
         opacity: 1;
       }
-      &:hover,
-      &:focus {
-        @include princeton-focus(light);
-      }
+      @include princeton-focus(light);
     }
 
     textarea {
@@ -467,10 +464,7 @@ $color-placeholder: tint(rgb(149, 156, 167), 50%);
     background-color: var(--color-white);
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
-    &:hover,
-    &:focus {
-      @include princeton-focus(light);
-    }
+    @include princeton-focus(light);
   }
 }
 </style>

--- a/src/components/LuxLibraryFooter.vue
+++ b/src/components/LuxLibraryFooter.vue
@@ -187,10 +187,7 @@ export default {
     .lux-library-links a {
       text-decoration: none;
       color: var(--color-white);
-      &:hover,
-      &:focus-visible {
-        @include princeton-focus(dark);
-      }
+      @include princeton-focus(dark);
     }
   }
 
@@ -200,10 +197,7 @@ export default {
     .lux-library-links a {
       text-decoration: none;
       color: var(----color-white);
-      &:hover,
-      &:focus-visible {
-        @include princeton-focus(dark);
-      }
+      @include princeton-focus(dark);
     }
   }
 
@@ -213,10 +207,7 @@ export default {
     .lux-library-links a {
       text-decoration: none;
       color: var(--color-rich-black);
-      &:hover,
-      &:focus-visible {
-        @include princeton-focus(dark);
-      }
+      @include princeton-focus(dark);
     }
   }
 }

--- a/src/components/LuxLibraryHeader.vue
+++ b/src/components/LuxLibraryHeader.vue
@@ -124,28 +124,14 @@ export default {
   &.dark {
     background: var(--color-gray-100);
     a.lux-app-name {
-      &:hover,
-      &:focus,
-      &:focus-visible {
-        outline: none;
-        span:not(:empty) {
-          @include princeton-focus(dark);
-        }
-      }
+      @include princeton-focus(dark);
     }
   }
 
   &.shade {
     background: var(--color-grayscale-darker);
     a.lux-app-name {
-      &:hover,
-      &:focus,
-      &:focus-visible {
-        outline: none;
-        span:not(:empty) {
-          @include princeton-focus(shade);
-        }
-      }
+      @include princeton-focus(shade);
     }
   }
 
@@ -156,14 +142,7 @@ export default {
       color: var(--color-rich-black);
     }
     a.lux-app-name {
-      &:hover,
-      &:focus,
-      &:focus-visible {
-        outline: none;
-        span:not(:empty) {
-          @include princeton-focus(light);
-        }
-      }
+      @include princeton-focus(light);
     }
   }
 }

--- a/src/components/LuxLibraryLogo.vue
+++ b/src/components/LuxLibraryLogo.vue
@@ -69,23 +69,21 @@ export default {
     }
   }
   &.light {
+    @include princeton-focus(light);
     &:hover,
     &:focus-within {
-      @include princeton-focus(light);
       outline-offset: 0.1rem;
     }
   }
   &.dark {
-    &:hover,
+    @include princeton-focus(dark);
     &:focus-within {
-      @include princeton-focus(dark);
       outline-offset: 0.1rem;
     }
   }
   &.shade {
-    &:hover,
+    @include princeton-focus(shade);
     &:focus-within {
-      @include princeton-focus(shade);
       outline-offset: 0.1rem;
     }
   }

--- a/src/components/LuxMenuBar.vue
+++ b/src/components/LuxMenuBar.vue
@@ -473,10 +473,7 @@ export default {
       }
 
       .lux-show a {
-        &:hover,
-        &:focus-visible {
-          @include princeton-focus(light);
-        }
+        @include princeton-focus(light);
       }
     }
 
@@ -591,10 +588,7 @@ export default {
 .dark {
   a,
   .lux-submenu-toggle {
-    &:hover,
-    &:focus-visible {
-      @include princeton-focus(dark);
-    }
+    @include princeton-focus(dark);
   }
   background: var(--color-gray-100);
 
@@ -630,10 +624,7 @@ export default {
 
   a,
   .lux-submenu-toggle {
-    &:hover,
-    &:focus-visible {
-      @include princeton-focus(shade);
-    }
+    @include princeton-focus(shade);
   }
 
   @media (max-width: 899px) {
@@ -667,10 +658,7 @@ export default {
   background: var(--color-white);
   a,
   .lux-submenu-toggle {
-    &:hover,
-    &:focus-visible {
-      @include princeton-focus(light);
-    }
+    @include princeton-focus(light);
   }
 
   :deep(.hamburger-inner),

--- a/src/components/_LuxLibraryContactInfo.vue
+++ b/src/components/_LuxLibraryContactInfo.vue
@@ -58,10 +58,7 @@ export default {
     background-color: var(--color-gray-100);
     a {
       color: var(--color-white);
-      &:hover,
-      &:focus-visible {
-        @include princeton-focus(dark);
-      }
+      @include princeton-focus(dark);
     }
 
     h2 {
@@ -74,10 +71,7 @@ export default {
     background-color: var(--color-grayscale-darker);
     a {
       color: var(--color-white);
-      &:hover,
-      &:focus-visible {
-        @include princeton-focus(dark);
-      }
+      @include princeton-focus(dark);
     }
 
     h2 {
@@ -90,10 +84,7 @@ export default {
     background-color: var(--color-white);
     a {
       color: var(--color-rich-black);
-      &:hover,
-      &:focus-visible {
-        @include princeton-focus(light);
-      }
+      @include princeton-focus(light);
     }
 
     h2 {

--- a/src/components/_LuxUniversityAccessibility.vue
+++ b/src/components/_LuxUniversityAccessibility.vue
@@ -59,10 +59,7 @@ export default {
     a {
       color: var(--color-white);
       background: var(--color-gray-100);
-      &:hover,
-      &:focus-visible {
-        @include princeton-focus(dark);
-      }
+      @include princeton-focus(dark);
     }
   }
 
@@ -70,10 +67,7 @@ export default {
     a {
       color: var(--color-white);
       background: var(--color-grayscale-darker);
-      &:hover,
-      &:focus-visible {
-        @include princeton-focus(shade);
-      }
+      @include princeton-focus(shade);
     }
   }
 
@@ -81,10 +75,7 @@ export default {
     a {
       color: var(--color-rich-black);
       background: var(--color-white);
-      &:hover,
-      &:focus-visible {
-        @include princeton-focus(light);
-      }
+      @include princeton-focus(light);
     }
   }
 }


### PR DESCRIPTION
This also adds an underline when hovering on links in the header, since there's no other visual indication.

Please review this, I don't work in this space very often!

Closes #303.

Thanks Max for pointing out princeton-focus