### PR TITLE
[LuxMenuBar] Emit menu-item-clicked event even when type=main-menu

### DIFF
--- a/src/components/LuxMenuBar.vue
+++ b/src/components/LuxMenuBar.vue
@@ -100,6 +100,7 @@
                 :target="child.target"
                 :data-method="child.method"
                 class="lux-nav-item"
+                @click="menuItemClicked(child)"
                 >{{ child.name }}</a
               >
             </li>
@@ -112,6 +113,7 @@
             :title="item.name"
             :data-method="item.method"
             class="lux-nav-item"
+            @click="menuItemClicked(item)"
           >
             {{ item.name }}
           </a>
@@ -231,6 +233,7 @@ export default {
       },
     },
   },
+  emits: ["input", "menu-item-clicked"],
 }
 </script>
 

--- a/tests/unit/specs/components/luxMenuBar.spec.js
+++ b/tests/unit/specs/components/luxMenuBar.spec.js
@@ -93,4 +93,17 @@ describe("LuxMenuBar.vue", () => {
   it("has the expected html structure", () => {
     expect(wrapper.element).toMatchSnapshot()
   })
+
+  describe("when type is main-menu", () => {
+    it("emits menu-item-clicked with metadata about the clicked menu item", async () => {
+      wrapper.setProps({ type: "main-menu" })
+      await nextTick()
+      wrapper.findAll(".lux-nav-item")[1].trigger("click")
+
+      expect(wrapper.emitted()["menu-item-clicked"].length).toEqual(1)
+      expect(wrapper.emitted()["menu-item-clicked"][0]).toEqual([
+        { name: "Bar", component: "Bar", href: "/example/" },
+      ])
+    })
+  })
 })


### PR DESCRIPTION
Prior to this commit, we only emitted this event when the type was links or buttons.

closes #315 