### PR TITLE
Create a new University Privacy notice component. Import it in the Library Footer

### DIFF
--- a/src/components/LuxLibraryFooter.vue
+++ b/src/components/LuxLibraryFooter.vue
@@ -31,6 +31,9 @@
               <li>
                 <a href="https://library.princeton.edu/about/jobs">Library Jobs</a>
               </li>
+              <li>
+                <lux-university-privacy-notice :theme="value(theme)" />
+              </li>
             </ul>
           </nav>
         </div>
@@ -64,6 +67,7 @@ import LuxLogoX from "./logos/LuxLogoX.vue"
 import LuxSubscribeNewsletter from "./_LuxSubscribeNewsletter.vue"
 import LuxUniversityAccessibility from "./_LuxUniversityAccessibility.vue"
 import LuxUniversityCopyright from "./_LuxUniversityCopyright.vue"
+import LuxUniversityPrivacyNotice from "./_LuxUniversityPrivacyNotice.vue"
 import LuxWrapper from "./LuxWrapper.vue"
 
 /**
@@ -88,6 +92,7 @@ export default {
     LuxSubscribeNewsletter,
     LuxUniversityAccessibility,
     LuxUniversityCopyright,
+    LuxUniversityPrivacyNotice,
     LuxWrapper,
   },
   methods: {
@@ -298,7 +303,6 @@ export default {
 
   ul {
     list-style-type: none;
-    margin-right: calc(70% - 10rem);
     display: flex;
     flex-flow: column wrap;
     align-content: center;

--- a/src/components/_LuxUniversityPrivacyNotice.vue
+++ b/src/components/_LuxUniversityPrivacyNotice.vue
@@ -1,0 +1,95 @@
+<template>
+  <component :is="type" :class="['lux-privacy-notice', theme]">
+    <LuxHyperlink href="https://www.princeton.edu/privacy-notice" :newTab="true"
+      >Princeton University Privacy Notice</LuxHyperlink
+    >
+  </component>
+</template>
+
+<script>
+import LuxHyperlink from "./LuxHyperlink.vue"
+
+/**
+ * Used to show the University’s Privacy Notice site in the footer.
+ */
+export default {
+  name: "LuxUniversityPrivacyNotice",
+  status: "ready",
+  release: "5.5.1",
+  type: "Element",
+
+  props: {
+    /**
+     * The html element name used for the wrapper.
+     */
+    type: {
+      type: String,
+      default: "span",
+    },
+    theme: {
+      type: String,
+      default: "dark",
+    },
+  },
+  components: {
+    LuxHyperlink,
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+@import "../assets/styles/spacing.scss";
+@import "../assets/styles/mixins.scss";
+@import "../assets/styles/variables.css";
+@import "../assets/styles/system.scss";
+@import "../assets/styles/focus.scss";
+
+.lux-privacy-notice {
+  @include reset;
+  @include stack-space(var(--space-base));
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-heading);
+
+  :deep(.lux-link) {
+    box-shadow: none;
+  }
+
+  a {
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  &.dark {
+    a {
+      color: var(--color-white);
+      background: var(--color-gray-100);
+      @include princeton-focus(dark);
+    }
+  }
+
+  &.shade {
+    a {
+      color: var(--color-white);
+      background: var(--color-grayscale-darker);
+      @include princeton-focus(shade);
+    }
+  }
+
+  &.light {
+    a {
+      color: var(--color-rich-black);
+      background: var(--color-white);
+      @include princeton-focus(light);
+    }
+  }
+}
+</style>
+
+<docs>
+  ```jsx
+  <div>
+    <lux-university-privacy-notice theme="light" type="span"></lux-university-privacy-notice>
+  </div>
+  ```
+</docs>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -16,6 +16,7 @@ import _LuxLibraryContactInfo from "./_LuxLibraryContactInfo.vue"
 import _LuxLibraryContactInfoOld from "./_LuxLibraryContactInfoOld.vue"
 import _LuxUniversityCopyright from "./_LuxUniversityCopyright.vue"
 import _LuxUniversityCopyrightOld from "./_LuxUniversityCopyrightOld.vue"
+import _LuxUniversityPrivacyNotice from "./_LuxUniversityPrivacyNotice.vue"
 import LuxBanner from "./LuxBanner.vue"
 import LuxCard from "./LuxCard.vue"
 import LuxCounter from "./LuxCounter.vue"
@@ -70,6 +71,7 @@ export {
   _LuxLibraryContactInfoOld,
   _LuxUniversityCopyright,
   _LuxUniversityCopyrightOld,
+  _LuxUniversityPrivacyNotice,
   LuxBanner,
   LuxCard,
   LuxCounter,

--- a/tests/unit/specs/components/luxUniversityPrivacyNotice.spec.js
+++ b/tests/unit/specs/components/luxUniversityPrivacyNotice.spec.js
@@ -1,0 +1,9 @@
+import { mount } from "@vue/test-utils"
+import _LuxUniversityPrivacyNotice from "@/components/_LuxUniversityPrivacyNotice.vue"
+
+describe("LuxUniversityPrivacyNotice component", () => {
+  it("tells screen reader users that it opens in a new tab", () => {
+    const wrapper = mount(_LuxUniversityPrivacyNotice)
+    expect(wrapper.text()).toContain("opens in new tab")
+  })
+})


### PR DESCRIPTION
[LuxUniversityPrivacyNotice] Create new component for University Privacy notice
[LuxLibraryFooter] Import LuxUniversityPrivacyNotice in the Library Footer; 
[LuxLibraryFooter] Remove margin-right so that in large screens the new link doesn't wrap the external icon

![Library Footer screenshot](https://github.com/user-attachments/assets/afb0f158-9cea-45ad-ad18-ec2adadc0c67)



