### PR TITLE
[Build] Define process.env.NODE_ENV as part of the vite build

### DIFF
--- a/docs/adding_lux.md
+++ b/docs/adding_lux.md
@@ -119,13 +119,6 @@ If you can't use an import map and have to use `<script src>` then from cdn use 
 
 Add the following `<script>` tags after the `<head>` tag:
 ```
-  <script>
-    window.process = {
-        env: {
-          NODE_ENV: 'production'
-        }
-      };
-  </script>
   <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
   <script src="https://unpkg.com/lux-design-system@5.5.0/dist/lux-styleguidist.iife.js"></script>
 ```

--- a/vite.config.js
+++ b/vite.config.js
@@ -26,6 +26,7 @@ export default defineConfig({
       hook: "writeBundle",
     }),
   ],
+  define: { "process.env.NODE_ENV": '"production"' },
   build: {
     lib: {
       // Could also be a dictionary or array of multiple entry points


### PR DESCRIPTION
This allows us to use Lux's IIFE distribution in <script src=""> without the error: "process is not defined"

See environments variable section under https://vitejs.dev/guide/build.html#library-mode

Related to https://github.com/pulibrary/libapps/issues/26