### PR TITLE
[LuxInputText] Don't use a text decoration on hover and on focus 

### DIFF
--- a/src/components/LuxInputText.vue
+++ b/src/components/LuxInputText.vue
@@ -389,6 +389,10 @@ $color-placeholder: tint(rgb(149, 156, 167), 50%);
         opacity: 1;
       }
       @include princeton-focus(light);
+      &:focus,
+      &:hover {
+        text-decoration: none;
+      }
     }
 
     textarea {
@@ -464,7 +468,10 @@ $color-placeholder: tint(rgb(149, 156, 167), 50%);
     background-color: var(--color-white);
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
-    @include princeton-focus(light);
+    &:focus,
+    &:hover {
+      text-decoration: none;
+    }
   }
 }
 </style>

--- a/src/components/LuxInputText.vue
+++ b/src/components/LuxInputText.vue
@@ -468,10 +468,6 @@ $color-placeholder: tint(rgb(149, 156, 167), 50%);
     background-color: var(--color-white);
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
-    &:focus,
-    &:hover {
-      text-decoration: none;
-    }
   }
 }
 </style>


### PR DESCRIPTION
closes #329 

- [LuxInputText] Remove focus indicator from append-icon. It's not doing anything. 
Currently it shows as:
![append-icon](https://github.com/user-attachments/assets/3ca450a9-7692-418f-847b-3da25a60e539)

- Will create a separate ticket for that ^

- [LuxInputText] On hover and focus, override text-decoration to be none;