### PR TITLE
Use lux variables to style the lux styleguide/documentation

### DIFF
--- a/docs/lux_usage.md
+++ b/docs/lux_usage.md
@@ -19,3 +19,4 @@
 * [Figgy](https://figgy.princeton.edu)
 * [Imagecat](https://imagecat.princeton.edu)
 * [Lib-Jobs](https://lib-jobs.princeton.edu)
+* [LUX Design System Documentation](https://pulibrary.github.io/lux-design-system)

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -27,4 +27,28 @@ module.exports = {
   exampleMode: "expand",
   enhancePreviewApp: path.join(__dirname, "styleguide_vue_app.js"),
   version: process.env.npm_package_version,
+  theme: {
+    fontFamily: {
+      base: "var(--font-family-text)",
+    },
+    color: {
+      light: "var(--color-grayscale-dark)",
+      sidebarBackground: "var(--color-grayscale-lighter)",
+      link: "var(--color-bleu-de-france)",
+      codeBackground: "var(--color-grayscale-lighter)",
+      codeKeyword: "var(--color-bleu-de-france-darker)",
+      codePunctuation: "var(--color-bleu-de-france-darker)",
+      codeProperty: "var(--color-gray-100)",
+      codeString: "var(--color-red)",
+    },
+  },
+  styles: {
+    Heading: {
+      heading2: {
+        fontFamily: "var(--font-family-heading)",
+        fontWeight: "var(--font-weight-bold)",
+        lineHeight: "var(--line-height-heading)",
+      },
+    },
+  },
 }


### PR DESCRIPTION
This gets rid of 1,373(!) color contrast violations, almost all of which come from the code editor.