### PR TITLE
[#301] Automatically generate design token documentation on commit and styleguide build

### DIFF
--- a/docs/design_tokens.md
+++ b/docs/design_tokens.md
@@ -1,0 +1,85 @@
+
+<!-- this documentation is automatically generated, please edit variables.css or generateDesignTokenDocs.mjs to make changes -->
+<style>
+  .swatch {
+    height: 100px;
+    width: 100px;
+    border: 1px solid black;
+  }
+  .spacing {
+    background: var(--color-grayscale-lighter);
+    width: 100%;
+    box-shadow: inset 0 0 0 1px rgba(0,0,0,0.05);
+    margin-bottom: 8px;
+  }
+</style>
+
+## Colors
+
+|Color|Variable|Value|
+|---|---|---|
+|<div class="swatch" style="background-color: rgb(197, 200, 206);"></div>|<pre>--color-grayscale-light</pre>|rgb(197, 200, 206);|
+|<div class="swatch" style="background-color: rgb(255, 252, 250);"></div>|<pre>--color-princeton-salmon-lighter</pre>|rgb(255, 252, 250);|
+|<div class="swatch" style="background-color: rgb(188, 139, 82);"></div>|<pre>--color-tan</pre>|rgb(188, 139, 82);|
+|<div class="swatch" style="background-color: rgb(45, 112, 180);"></div>|<pre>--color-bleu-de-france-dark</pre>|rgb(45, 112, 180);|
+|<div class="swatch" style="background-color: rgb(108, 163, 218);"></div>|<pre>--color-bleu-de-france-light</pre>|rgb(108, 163, 218);|
+|<div class="swatch" style="background-color: rgb(124, 181, 24);"></div>|<pre>--color-green</pre>|rgb(124, 181, 24);|
+|<div class="swatch" style="background-color: rgb(231, 117, 0);"></div>|<pre>--color-princeton-orange-on-white</pre>|rgb(231, 117, 0);|
+|<div class="swatch" style="background-color: rgb(92, 84, 51);"></div>|<pre>--color-grayscale-warm-darker</pre>|rgb(92, 84, 51);|
+|<div class="swatch" style="background-color: rgb(219, 193, 163);"></div>|<pre>--color-tan-lighter</pre>|rgb(219, 193, 163);|
+|<div class="swatch" style="background-color: rgb(107, 115, 128);"></div>|<pre>--color-grayscale-dark</pre>|rgb(107, 115, 128);|
+|<div class="swatch" style="background-color: rgb(149, 156, 167);"></div>|<pre>--color-grayscale</pre>|rgb(149, 156, 167);|
+|<div class="swatch" style="background-color: rgb(255, 255, 255);"></div>|<pre>--color-white</pre>|rgb(255, 255, 255);|
+|<div class="swatch" style="background-color: rgb(245, 245, 245);"></div>|<pre>--color-grayscale-lighter</pre>|rgb(245, 245, 245);|
+|<div class="swatch" style="background-color: rgb(210, 202, 173);"></div>|<pre>--color-grayscale-warm-light</pre>|rgb(210, 202, 173);|
+|<div class="swatch" style="background-color: rgb(255, 186, 10);"></div>|<pre>--color-yellow</pre>|rgb(255, 186, 10);|
+|<div class="swatch" style="background-color: rgb(44, 110, 175);"></div>|<pre>--color-bleu-de-france</pre>|rgb(44, 110, 175);|
+|<div class="swatch" style="background-color: rgb(158, 113, 61);"></div>|<pre>--color-tan-dark</pre>|rgb(158, 113, 61);|
+|<div class="swatch" style="background-color: rgb(35, 87, 139);"></div>|<pre>--color-bleu-de-france-darker</pre>|rgb(35, 87, 139);|
+|<div class="swatch" style="background-color: rgb(149, 189, 228);"></div>|<pre>--color-bleu-de-france-lighter</pre>|rgb(149, 189, 228);|
+|<div class="swatch" style="background-color: rgb(201, 40, 19);"></div>|<pre>--color-red</pre>|rgb(201, 40, 19);|
+|<div class="swatch" style="background-color: rgb(255, 227, 199);"></div>|<pre>--color-princeton-salmon-light</pre>|rgb(255, 227, 199);|
+|<div class="swatch" style="background-color: rgb(65, 70, 78);"></div>|<pre>--color-grayscale-darker</pre>|rgb(65, 70, 78);|
+|<div class="swatch" style="background-color: rgb(0, 17, 35);"></div>|<pre>--color-rich-black</pre>|rgb(0, 17, 35);|
+|<div class="swatch" style="background-color: rgb(186, 175, 130);"></div>|<pre>--color-grayscale-warm</pre>|rgb(186, 175, 130);|
+|<div class="swatch" style="background-color: rgb(151, 138, 83);"></div>|<pre>--color-grayscale-warm-dark</pre>|rgb(151, 138, 83);|
+|<div class="swatch" style="background-color: rgb(202, 163, 119);"></div>|<pre>--color-tan-light</pre>|rgb(202, 163, 119);|
+|<div class="swatch" style="background-color: rgb(250, 249, 245);"></div>|<pre>--color-grayscale-warm-lighter</pre>|rgb(250, 249, 245);|
+|<div class="swatch" style="background-color: rgb(121, 87, 47);"></div>|<pre>--color-tan-darker</pre>|rgb(121, 87, 47);|
+|<div class="swatch" style="background-color: rgb(255, 201, 148);"></div>|<pre>--color-princeton-salmon</pre>|rgb(255, 201, 148);|
+|<div class="swatch" style="background-color: rgb(245, 128, 37);"></div>|<pre>--color-princeton-orange-on-black</pre>|rgb(245, 128, 37);|
+|<div class="swatch" style="background-color: #E77500;"></div>|<pre>--color-princeton-orange-50</pre>|#E77500;|
+|<div class="swatch" style="background-color: #FCF1E5;"></div>|<pre>--color-princeton-orange-10</pre>|#FCF1E5;|
+|<div class="swatch" style="background-color: #121212;"></div>|<pre>--color-gray-100</pre>|#121212;|
+
+## Font sizes
+
+|Variable|Value|
+|---|---|
+    |<span style="font-size: 1.125em;">--font-size-large-min</span>|1.125em;|
+|<span style="font-size: 1.125em;">--font-size-base-max</span>|1.125em;|
+|<span style="font-size: 36px;">--font-size-x-large</span>|36px;|
+|<span style="font-size: 64px;">--font-size-xxx-large</span>|64px;|
+|<span style="font-size: 48px;">--font-size-xx-large</span>|48px;|
+|<span style="font-size: 1.777em;">--font-size-x-large-max</span>|1.777em;|
+|<span style="font-size: 3.157em;">--font-size-xxx-large-max</span>|3.157em;|
+|<span style="font-size: 24px;">--font-size-large</span>|24px;|
+|<span style="font-size: 2.369em;">--font-size-xx-large-max</span>|2.369em;|
+|<span style="font-size: 1.333em;">--font-size-large-max</span>|1.333em;|
+|<span style="font-size: 12px;">--font-size-x-small</span>|12px;|
+|<span style="font-size: 1em;">--font-size-base-min</span>|1em;|
+|<span style="font-size: 14px;">--font-size-small</span>|14px;|
+|<span style="font-size: 1.266em;">--font-size-x-large-min</span>|1.266em;|
+|<span style="font-size: 1.602em;">--font-size-xxx-large-min</span>|1.602em;|
+|<span style="font-size: 1.424em;">--font-size-xx-large-min</span>|1.424em;|
+|<span style="font-size: 16px;">--font-size-base</span>|16px;|
+
+## Spacing
+
+<div class="spacing" style="height: 128px;;line-height: 128px;">--space-xx-large (128px;)</div>
+<div class="spacing" style="height: 64px;;line-height: 64px;">--space-x-large (64px;)</div>
+<div class="spacing" style="height: 48px;;line-height: 48px;">--space-large (48px;)</div>
+<div class="spacing" style="height: 24px;;line-height: 24px;">--space-base (24px;)</div>
+<div class="spacing" style="height: 16px;;line-height: 16px;">--space-small (16px;)</div>
+<div class="spacing" style="height: 8px;;line-height: 8px;">--space-x-small (8px;)</div>
+<div class="spacing" style="height: 4px;;line-height: 4px;">--space-xx-small (4px;)</div>

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "lint": "vue-cli-service lint",
     "deploy": "npm run build; npm run styleguide:build; push-dir --dir=styleguide --branch=gh-pages --cleanup",
     "release": "npm run build && np && npm run deploy",
-    "styleguide": "vue-cli-service styleguidist",
-    "styleguide:build": "vue-cli-service styleguidist:build"
+    "styleguide": "npm run design_tokens:docs:build && vue-cli-service styleguidist",
+    "styleguide:build": "npm run design_tokens:docs:build && vue-cli-service styleguidist:build",
+    "design_tokens:docs:build": "node src/utils/generateDesignTokenDocs.mjs"
   },
   "dependencies": {
     "core-js": "^3.8.3",
@@ -71,6 +72,6 @@
     "vue-cli-plugin-styleguidist": "~4.72.4"
   },
   "gitHooks": {
-    "pre-commit": "lint-staged"
+    "pre-commit": "npm run design_tokens:docs:build && lint-staged"
   }
 }

--- a/src/utils/generateDesignTokenDocs.mjs
+++ b/src/utils/generateDesignTokenDocs.mjs
@@ -1,0 +1,127 @@
+import { open, appendFile } from "node:fs/promises"
+
+// This class is responsible for reading CSS variables from
+// a CSS file, and generating a Markdown file for developers
+// that describes those variables.
+export class DesignTokenDocs {
+  async generate(
+    cssFilePath="src/assets/styles/variables.css",
+    designTokenDocsPath = "docs/design_tokens.md"
+  ) {
+    this.cssVarsFileHandle = await open(cssFilePath)
+    this.designTokenDocsFileHandle = await open(designTokenDocsPath, 'w')
+
+    await this.#extractDesignTokens()
+
+    await this.#writeStyles()
+    await this.#writeColorTable()
+    await this.#writeFontSizes()
+    await this.#writeSpacing()
+
+    await this.#cleanup();
+  }
+
+  // This method is responsible for parsing the CSS file
+  // into arrays of color tokens, font size tokens, and
+  // spacing tokens.
+  async #extractDesignTokens() {
+    this.colors = []
+    this.fontSizes = []
+    this.spacings = []
+
+    for await (const line of this.cssVarsFileHandle.readLines()) {
+      const data = line.split(":").map(tokenData => tokenData.trim())
+      switch(this.#tokenType(line)) {
+        case 'color':
+          this.colors.push(data)
+          break
+        case 'font-size':
+          this.fontSizes.push(data)
+          break
+        case 'spacing':
+          this.spacings.push(data)
+          break
+      }
+    }
+  }
+
+  #tokenType(cssLine) {
+    if (cssLine.includes("--color")) {
+      return 'color'
+    } else if (cssLine.includes("--font-size")) {
+      return 'font-size'
+    } else if (cssLine.includes("--space")) {
+      return 'spacing'
+    }
+    return 'other'
+  }
+
+  async #writeStyles() {
+    await appendFile(
+      this.designTokenDocsFileHandle, `
+<!-- this documentation is automatically generated, please edit variables.css or generateDesignTokenDocs.mjs to make changes -->
+<style>
+  .swatch {
+    height: 100px;
+    width: 100px;
+    border: 1px solid black;
+  }
+  .spacing {
+    background: var(--color-grayscale-lighter);
+    width: 100%;
+    box-shadow: inset 0 0 0 1px rgba(0,0,0,0.05);
+    margin-bottom: 8px;
+  }
+</style>\n`);
+  }
+
+  async #writeColorTable() {
+    await appendFile(this.designTokenDocsFileHandle, `
+## Colors
+
+|Color|Variable|Value|
+|---|---|---|
+`);
+    for (const colorData of this.colors) {
+      await appendFile(
+        this.designTokenDocsFileHandle,
+        `|<div class="swatch" style="background-color: ${colorData[1]}"></div>|<pre>${colorData[0]}</pre>|${colorData[1]}|\n`
+      )
+    }
+  }
+
+  async #writeFontSizes() {
+    await appendFile(this.designTokenDocsFileHandle, `
+## Font sizes
+
+|Variable|Value|
+|---|---|
+    `);
+    for (const fontSizeData of this.fontSizes) {
+      await appendFile(
+        this.designTokenDocsFileHandle,
+        `|<span style="font-size: ${fontSizeData[1]}">${fontSizeData[0]}</span>|${fontSizeData[1]}|\n`
+      )
+    }
+  }
+
+  async #writeSpacing() {
+    await appendFile(this.designTokenDocsFileHandle, "\n## Spacing\n\n");
+    for (const spacingData of this.spacings) {
+      await appendFile(
+        this.designTokenDocsFileHandle,
+        `<div class="spacing" style="height: ${spacingData[1]};line-height: ${spacingData[1]}">${spacingData[0]} (${spacingData[1]})</div>\n`
+      )
+    }
+  }
+
+  async #cleanup() {
+    return await Promise.allSettled([
+      this.cssVarsFileHandle.close(),
+      this.designTokenDocsFileHandle.close()
+    ]);
+  }
+
+}
+
+new DesignTokenDocs().generate().then(_ => console.log('Re-generated design token documentation'))

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -8,6 +8,10 @@ module.exports = {
   pagePerSection: true,
   sections: [
     {
+      name: "Design Tokens",
+      content: "docs/design_tokens.md",
+    },
+    {
       name: "Components",
       components: "src/components/[A-Z]*.vue",
     },


### PR DESCRIPTION
This gives us some documentation like we had in Lux versions 4 and earlier (see https://pulibrary.github.io/lux/docs/#/Design%20Tokens), where developers can get a visual of all the color, font size, and spacing design tokens on one page.

Closes #301