### PR TITLE
right aligning the footer

### DIFF
--- a/src/components/LuxLibraryFooter.vue
+++ b/src/components/LuxLibraryFooter.vue
@@ -282,7 +282,8 @@ export default {
   }
 
   &.pu-logo-white {
-    align-content: center;
+    align-content: end;
+    padding-right: 0.5rem;
     @media (max-width: 899px) {
       align-content: flex-start;
     }


### PR DESCRIPTION
Aligning bottom most Princeton logo with the right-most element of the footer
addresses @hackartisan comments on #307 