### PR TITLE
[LuxMenuBar] closes dropdowns when you press esc

### DIFF
--- a/src/components/LuxMenuBar.vue
+++ b/src/components/LuxMenuBar.vue
@@ -88,6 +88,7 @@
             class="lux-submenu-toggle"
             :data-method="item.method"
             @click="setActiveItem(index)"
+            @keydown.esc="activeItem ? setActiveItem(index) : 'false'"
           >
             <lux-menu-bar-label :item="item"></lux-menu-bar-label>
           </button>


### PR DESCRIPTION
Fixes #340
Co-authored-by: Jane Sandberg <sandbergja@users.noreply.github.com>