### PR TITLE
Remove right padding 2rem from the library links ul

### DIFF
--- a/src/components/LuxLibraryFooter.vue
+++ b/src/components/LuxLibraryFooter.vue
@@ -333,7 +333,6 @@ export default {
     list-style-type: none;
     display: flex;
     flex-flow: column wrap;
-    padding-right: 2rem;
     @media (max-width: 899px) {
       padding: 0rem 2rem 0rem 0rem;
       align-content: flex-start;


### PR DESCRIPTION
The library links are not anymore align-content right, so there is no need to push them to the left.