### PR TITLE
Split out a university footer

### DIFF
--- a/src/components/LuxLibraryFooter.vue
+++ b/src/components/LuxLibraryFooter.vue
@@ -54,9 +54,12 @@ import LuxLogoInstagram from "./logos/LuxLogoInstagram.vue"
 import LuxLogoX from "./logos/LuxLogoX.vue"
 import LuxSubscribeNewsletter from "./_LuxSubscribeNewsletter.vue"
 import LuxWrapper from "./LuxWrapper.vue"
+import LuxUniversityFooter from "./LuxUniversityFooter.vue"
 
 /**
- * LibraryFooter is the preferred Footer styling/behavior for the PUL main website.
+ * LibraryFooter is the preferred Footer styling/behavior for the PUL main
+ * website. Other sites tightly integrated with the main site may also want
+ * to use this footer.
  * Don't forget to create a fallback for this component by providing the HTML
  * rendering in _<noscript></noscript>_ tags.
  */
@@ -75,6 +78,7 @@ export default {
     LuxLogoX,
     LuxSubscribeNewsletter,
     LuxWrapper,
+    LuxUniversityFooter,
   },
   methods: {
     value: function (theme) {

--- a/src/components/LuxLibraryFooter.vue
+++ b/src/components/LuxLibraryFooter.vue
@@ -35,9 +35,6 @@
               <li>
                 <a href="https://library.princeton.edu/about/employment">Library Jobs</a>
               </li>
-              <li>
-                <lux-university-privacy-notice :theme="value(theme)" />
-              </li>
             </ul>
           </nav>
         </div>
@@ -56,11 +53,10 @@ import LuxLogoGovDocs from "./logos/LuxLogoGovDocs.vue"
 import LuxLogoInstagram from "./logos/LuxLogoInstagram.vue"
 import LuxLogoX from "./logos/LuxLogoX.vue"
 import LuxSubscribeNewsletter from "./_LuxSubscribeNewsletter.vue"
-import LuxUniversityPrivacyNotice from "./_LuxUniversityPrivacyNotice.vue"
 import LuxWrapper from "./LuxWrapper.vue"
 
 /**
- * LibraryFooter is the preferred Footer styling/behavior for PUL websites.
+ * LibraryFooter is the preferred Footer styling/behavior for the PUL main website.
  * Don't forget to create a fallback for this component by providing the HTML
  * rendering in _<noscript></noscript>_ tags.
  */
@@ -78,7 +74,6 @@ export default {
     LuxLogoInstagram,
     LuxLogoX,
     LuxSubscribeNewsletter,
-    LuxUniversityPrivacyNotice,
     LuxWrapper,
   },
   methods: {

--- a/src/components/LuxUniversityFooter.vue
+++ b/src/components/LuxUniversityFooter.vue
@@ -1,61 +1,27 @@
 <template>
-  <component :is="type" :class="['lux-library-footer', theme]">
+  <component :is="type" :class="['lux-university-footer', theme]">
     <lux-wrapper class="lux-footer-content" :maxWidth="maxWidth">
-      <div class="lux-footer-main">
-        <div class="lux-library-links contact-info-layout">
-          <div>
-            <lux-library-logo width="245" height="54" :theme="value(theme)" />
-            <lux-library-contact-info :theme="value(theme)" />
-          </div>
-        </div>
-        <div class="lux-library-links subscribe-layout">
-          <h2>Subscribe to our Newsletter</h2>
-          <lux-subscribe-newsletter type="div" />
-          <div class="social-pul-icons">
-            <a href="https://x.com/PULibrary"><lux-logo-x width="24" height="24" /></a>
-            <a href="http://www.facebook.com/PULibrary"
-              ><lux-logo-facebook width="24" height="24"
-            /></a>
-            <a href="https://www.instagram.com/PULibrary/"
-              ><lux-logo-instagram width="24" height="24"
-            /></a>
-            <a href="https://libguides.princeton.edu/usgovdocs"
-              ><lux-logo-gov-docs width="30" height="30"
-            /></a>
-            <a href="https://fpul.princeton.edu/"><lux-logo-friends width="120" height="35" /></a>
-          </div>
-        </div>
+      <div class="lux-footer-bottom bottom-layout">
         <div class="lux-library-links">
-          <nav role="navigation" aria-label="Library Staff">
-            <ul>
-              <li><a href="https://library.princeton.edu/library-staff">For Library Staff</a></li>
-              <li>
-                <a href="https://library.princeton.edu/about/staff-directory">Staff Directory</a>
-              </li>
-              <li>
-                <a href="https://library.princeton.edu/about/employment">Library Jobs</a>
-              </li>
-              <li>
-                <lux-university-privacy-notice :theme="value(theme)" />
-              </li>
-            </ul>
-          </nav>
+          <lux-university-accessibility :theme="value(theme)" />
+        </div>
+        <div class="lux-library-links center-panel">
+          <lux-university-copyright type="div" :theme="value(theme)" />
+        </div>
+        <div class="lux-library-links pu-logo-white">
+          <a href="https://www.princeton.edu"
+            ><lux-logo-university-white width="200px" height="72px" type="div"
+          /></a>
         </div>
       </div>
     </lux-wrapper>
-    <lux-university-footer :theme="value(theme)" />
   </component>
 </template>
 
 <script>
-import LuxLibraryContactInfo from "./_LuxLibraryContactInfo.vue"
-import LuxLibraryLogo from "./LuxLibraryLogo.vue"
-import LuxLogoFacebook from "./logos/LuxLogoFacebook.vue"
-import LuxLogoFriends from "./logos/LuxLogoFriends.vue"
-import LuxLogoGovDocs from "./logos/LuxLogoGovDocs.vue"
-import LuxLogoInstagram from "./logos/LuxLogoInstagram.vue"
-import LuxLogoX from "./logos/LuxLogoX.vue"
-import LuxSubscribeNewsletter from "./_LuxSubscribeNewsletter.vue"
+import LuxUniversityAccessibility from "./_LuxUniversityAccessibility.vue"
+import LuxUniversityCopyright from "./_LuxUniversityCopyright.vue"
+import LuxLogoUniversityWhite from "./logos/LuxLogoUniversityWhite.vue"
 import LuxUniversityPrivacyNotice from "./_LuxUniversityPrivacyNotice.vue"
 import LuxWrapper from "./LuxWrapper.vue"
 
@@ -65,22 +31,18 @@ import LuxWrapper from "./LuxWrapper.vue"
  * rendering in _<noscript></noscript>_ tags.
  */
 export default {
-  name: "LuxLibraryFooter",
+  name: "LuxUniversityFooter",
   status: "ready",
   release: "1.0.0",
   type: "Pattern",
   components: {
-    LuxLibraryContactInfo,
-    LuxLibraryLogo,
-    LuxLogoFacebook,
-    LuxLogoFriends,
-    LuxLogoGovDocs,
-    LuxLogoInstagram,
-    LuxLogoX,
-    LuxSubscribeNewsletter,
+    LuxLogoUniversityWhite,
+    LuxUniversityAccessibility,
+    LuxUniversityCopyright,
     LuxUniversityPrivacyNotice,
     LuxWrapper,
   },
+
   methods: {
     value: function (theme) {
       if (theme == "light" || theme == "shade") {
@@ -89,6 +51,7 @@ export default {
       return "dark"
     },
   },
+
   props: {
     /**
      * The html element name used for the container
@@ -122,74 +85,17 @@ export default {
 @import "../assets/styles/system.scss";
 @import "../assets/styles/focus.scss";
 
-.contact-info-layout {
-  @media (min-width: 900px) {
-    border-right: 1px solid rgba(255, 255, 255, 0.3);
-    > div {
-      padding-left: 8px;
-    }
-  }
-
-  @media (max-width: 899px) {
-    /* on phone sizes it stacks */
-    border-bottom: 1px solid rgba(255, 255, 255, 0.3);
-  }
-}
-
-.subscribe-layout {
-  @media (min-width: 900px) {
-    border-right: 1px solid rgba(255, 255, 255, 0.3);
-    padding: 0rem 2rem 0rem 2rem;
-  }
-  @media (max-width: 899px) {
-    border-bottom: 1px solid rgba(255, 255, 255, 0.3);
-  }
-}
-
-.social-pul-icons {
-  display: flex;
-  flex-flow: row nowrap;
-  width: 300px;
-  align-items: flex-end;
-  justify-content: space-between;
-  @media (max-width: 899px) {
-    width: 200px;
-  }
-}
-
 .bottom-layout {
   border-top: 1px solid rgba(255, 255, 255, 0.3);
 }
 
-.lux-logo-x {
-  margin: 0.5rem 0.1rem 0rem 0.2rem;
-}
-
-.lux-logo-facebook {
-  margin: 0.5rem 0.2rem 0rem 0.1rem;
-}
-
-.lux-logo-instagram {
-  margin: 0.5rem 0.25rem 0rem 0.2rem;
-}
-
-.lux-logo-gov-docs {
-  margin: 0.5rem 0.1rem 0rem 0.3rem;
-}
-
-.lux-logo-friends {
-  margin: 0.5rem 0.2rem -0.2rem 0.2rem;
-}
-.lux-library-footer {
+.lux-university-footer {
   @include reset;
   @include stack-space(var(--space-base));
   font-family: var(--font-family-heading);
   line-height: var(--line-height-heading);
   color: var(--color-white);
   background: var(--color-gray-100);
-  @media (min-width: 900px) {
-    padding-top: 1em;
-  }
 
   &.dark {
     .lux-library-links a {
@@ -241,6 +147,21 @@ export default {
   }
 }
 
+.lux-footer-bottom {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+
+  @media (min-width: 900px) {
+    max-width: 1440px;
+  }
+  @media (max-width: 899px) {
+    flex-direction: column;
+    padding-top: 10px;
+    padding-bottom: 8px;
+  }
+}
+
 .lux-footer-content {
   display: flex;
   flex-direction: column;
@@ -281,12 +202,6 @@ export default {
     }
   }
 
-  h2 {
-    font-family: var(--font-family-heading);
-    font-size: var(--font-size-base);
-    font-weight: var(--font-weight-bold);
-  }
-
   a {
     color: var(--color-white);
 
@@ -324,7 +239,7 @@ export default {
 <docs>
   ```jsx
   <div>
-    <lux-library-footer theme="dark"></lux-library-footer>
+    <lux-university-footer theme="dark"></lux-university-footer>
   </div>
   ```
 </docs>

--- a/src/components/LuxUniversityFooter.vue
+++ b/src/components/LuxUniversityFooter.vue
@@ -38,7 +38,9 @@ import LuxUniversityPrivacyNotice from "./_LuxUniversityPrivacyNotice.vue"
 import LuxWrapper from "./LuxWrapper.vue"
 
 /**
- * UniversityFooter is the preferred Footer styling/behavior for PUL websites.
+ * UniversityFooter includes footer elements required by the University. It may
+ * be used when the LibraryFooter is too heavy for or not fully relevant to the
+ * site in question.
  * Don't forget to create a fallback for this component by providing the HTML
  * rendering in _<noscript></noscript>_ tags.
  */

--- a/src/components/LuxUniversityFooter.vue
+++ b/src/components/LuxUniversityFooter.vue
@@ -2,13 +2,26 @@
   <component :is="type" :class="['lux-university-footer', theme]">
     <lux-wrapper class="lux-footer-content" :maxWidth="maxWidth">
       <div class="lux-footer-bottom bottom-layout">
-        <div class="lux-library-links">
-          <lux-university-accessibility :theme="value(theme)" />
+        <div class="lux-university-links">
+          <div class="policy-links">
+            <LuxHyperlink
+              href="https://library.princeton.edu/about/policies/copyright-and-permissions-policies"
+            >
+              Copyright Policy</LuxHyperlink
+            >
+            |
+            <LuxHyperlink href="https://www.princeton.edu/privacy-notice">
+              Privacy Notice
+            </LuxHyperlink>
+          </div>
+          <LuxHyperlink href="https://accessibility.princeton.edu/help"
+            >Accessibility Help</LuxHyperlink
+          >
         </div>
-        <div class="lux-library-links center-panel">
+        <div class="lux-university-links center-panel">
           <lux-university-copyright type="div" :theme="value(theme)" />
         </div>
-        <div class="lux-library-links pu-logo-white">
+        <div class="lux-university-links pu-logo-white">
           <a href="https://www.princeton.edu"
             ><lux-logo-university-white width="200px" height="72px" type="div"
           /></a>
@@ -19,14 +32,13 @@
 </template>
 
 <script>
-import LuxUniversityAccessibility from "./_LuxUniversityAccessibility.vue"
 import LuxUniversityCopyright from "./_LuxUniversityCopyright.vue"
 import LuxLogoUniversityWhite from "./logos/LuxLogoUniversityWhite.vue"
 import LuxUniversityPrivacyNotice from "./_LuxUniversityPrivacyNotice.vue"
 import LuxWrapper from "./LuxWrapper.vue"
 
 /**
- * LibraryFooter is the preferred Footer styling/behavior for PUL websites.
+ * UniversityFooter is the preferred Footer styling/behavior for PUL websites.
  * Don't forget to create a fallback for this component by providing the HTML
  * rendering in _<noscript></noscript>_ tags.
  */
@@ -37,7 +49,6 @@ export default {
   type: "Pattern",
   components: {
     LuxLogoUniversityWhite,
-    LuxUniversityAccessibility,
     LuxUniversityCopyright,
     LuxUniversityPrivacyNotice,
     LuxWrapper,
@@ -98,9 +109,8 @@ export default {
   background: var(--color-gray-100);
 
   &.dark {
-    .lux-library-links a {
-      text-decoration: underline;
-      text-underline-offset: 3px;
+    a {
+      text-decoration: none;
       color: var(--color-white);
       @include princeton-focus(dark);
     }
@@ -109,9 +119,8 @@ export default {
   &.shade {
     background: var(--color-grayscale-darker);
 
-    .lux-library-links a {
-      text-decoration: underline;
-      text-underline-offset: 3px;
+    a {
+      text-decoration: none;
       color: var(----color-white);
       @include princeton-focus(dark);
     }
@@ -120,29 +129,10 @@ export default {
   &.light {
     background: var(--color-white);
 
-    .lux-library-links a {
-      text-decoration: underline;
-      text-underline-offset: 3px;
+    a {
+      text-decoration: none;
       color: var(--color-rich-black);
       @include princeton-focus(dark);
-    }
-  }
-}
-
-.lux-footer-main {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  padding: 0rem 0rem 1rem 0rem;
-
-  @media (min-width: 900px) {
-    max-width: 1440px;
-  }
-  @media (max-width: 899px) {
-    flex-direction: column;
-    > div {
-      padding-bottom: 8px;
-      padding-top: 8px;
     }
   }
 }
@@ -174,7 +164,7 @@ export default {
   }
 }
 
-.lux-library-links {
+.lux-university-links {
   order: 0;
   display: flex;
   flex-flow: column wrap;
@@ -182,6 +172,10 @@ export default {
   justify-content: center;
   @media (min-width: 900px) {
     flex: 1;
+  }
+
+  .policy-links {
+    display: flow-root;
   }
 
   &.pu-logo-white {
@@ -199,38 +193,6 @@ export default {
     }
     @media (max-width: 899px) {
       padding-top: 1em;
-    }
-  }
-
-  a {
-    color: var(--color-white);
-
-    &:hover,
-    &:focus {
-      text-decoration: underline;
-    }
-  }
-
-  ul {
-    list-style-type: none;
-    display: flex;
-    flex-flow: column wrap;
-    @media (max-width: 899px) {
-      padding: 0rem 2rem 0rem 0rem;
-      align-content: flex-start;
-      margin-bottom: 0px;
-    }
-
-    li:not(:last-child) {
-      padding-bottom: 1rem;
-    }
-    li {
-      line-height: var(--line-height-heading);
-      font-size: var(--font-size-base);
-      a {
-        text-decoration: underline;
-        text-underline-offset: 3px;
-      }
     }
   }
 }


### PR DESCRIPTION
- Separate university footer from library footer
- Adjust library and university footer contents

closes #360

Screenshots:

University Footer on its own

![Screenshot 2024-10-21 at 10 33 10 AM](https://github.com/user-attachments/assets/7dcf519c-135a-4e45-bb2a-3db33a0fe943)
![Screenshot 2024-10-21 at 10 33 52 AM](https://github.com/user-attachments/assets/aa0d132d-adf3-4c5a-bba9-1e96793087b1)

Library Footer with adjustments


![Screenshot 2024-10-21 at 10 33 01 AM](https://github.com/user-attachments/assets/ea0f10e1-2336-4389-8518-6833bd58e129)
![Screenshot 2024-10-21 at 10 33 32 AM](https://github.com/user-attachments/assets/d5beebe7-f89a-498b-a149-00b6b0182708)


