### PR TITLE
Explicitly left-align links in University Footer

### DIFF
--- a/src/components/LuxUniversityFooter.vue
+++ b/src/components/LuxUniversityFooter.vue
@@ -4,19 +4,17 @@
       <div class="lux-footer-bottom bottom-layout">
         <div class="lux-university-links">
           <div class="policy-links">
-            <LuxHyperlink
+            <a
               href="https://library.princeton.edu/about/policies/copyright-and-permissions-policies"
             >
-              Copyright Policy</LuxHyperlink
+              Copyright Policy</a
             >
             |
-            <LuxHyperlink href="https://www.princeton.edu/privacy-notice">
-              Privacy Notice
-            </LuxHyperlink>
+            <a href="https://www.princeton.edu/privacy-notice">Privacy Notice</a>
           </div>
-          <LuxHyperlink href="https://accessibility.princeton.edu/help"
-            >Accessibility Help</LuxHyperlink
-          >
+          <div class="policy-links">
+            <a href="https://accessibility.princeton.edu/help">Accessibility Help</a>
+          </div>
         </div>
         <div class="lux-university-links center-panel">
           <lux-university-copyright type="div" :theme="value(theme)" />
@@ -178,6 +176,7 @@ export default {
 
   .policy-links {
     display: flow-root;
+    text-align: left;
   }
 
   &.pu-logo-white {


### PR DESCRIPTION
closes #366 

Also fix bug where there were two hover underlines, one orange and one
white, by using regular link instead of LuxHyperLink

screenshots:
![Screenshot 2024-10-21 at 5 22 42 PM](https://github.com/user-attachments/assets/b013514a-0fdd-4528-a73f-fd625f38e979)
![Screenshot 2024-10-21 at 5 23 25 PM](https://github.com/user-attachments/assets/c345dac6-5791-46f6-9827-fca020da4fb0)

with hover:
![Screenshot 2024-10-21 at 5 23 04 PM](https://github.com/user-attachments/assets/6140300b-8658-4930-89df-0335839b2f96)
