### PR TITLE
[LuxInputCheckbox/Radio] Use a visible checkbox and radio, rather than hiding them

### DIFF
--- a/src/components/LuxDatePicker.vue
+++ b/src/components/LuxDatePicker.vue
@@ -293,7 +293,7 @@ function stringSeemsLikeDateRange(possibleRange) {
   flex-wrap: wrap;
 }
 
-.lux-input label {
+.lux-date-picker .lux-input label {
   display: inline-block;
   width: 100%;
 }

--- a/src/components/LuxInputCheckbox.vue
+++ b/src/components/LuxInputCheckbox.vue
@@ -131,6 +131,7 @@ export default {
 @import "../assets/styles/mixins.scss";
 @import "../assets/styles/variables.css";
 @import "../assets/styles/system.scss";
+@import "../assets/styles/focus.scss";
 
 fieldset {
   border: 0;
@@ -138,8 +139,6 @@ fieldset {
 }
 
 .lux-input {
-  @include stack-space(var(--space-small));
-
   font-weight: var(--font-weight-regular);
   font-family: var(--font-family-text);
   font-size: var(--font-size-base);
@@ -154,92 +153,30 @@ fieldset {
 }
 
 .lux-checkbox {
-  @include reset;
-  @include stack-space(var(--space-x-small));
   font-family: var(--font-family-text);
   line-height: var(--line-height-base);
-}
-
-.lux-checkbox input[type="checkbox"] {
-  @include visually-hidden;
-  &:focus {
-    box-shadow: inset 0 1px 0 0 rgba($color-rich-black, 0.07),
-      0 0 0 1px tint($color-rich-black, 80%);
-  }
+  display: flex;
 }
 
 .lux-checkbox label {
-  position: relative;
-  display: inline-block;
-  margin-bottom: var(--space-xx-small);
   cursor: pointer;
-  padding-left: var(--space-base);
+  margin-left: var(--space-xx-small);
 }
 
-.lux-checkbox label::before,
-.lux-checkbox label::after {
-  position: absolute;
-  content: "";
-
-  /*Needed for the line-height to take effect*/
+label {
   display: inline-block;
+  margin-top: calc(var(--font-size-base) * 0.175);
+  margin-bottom: calc(var(--font-size-base) * 0.175);
 }
 
-/*Outer box of the fake checkbox*/
-.lux-checkbox label::before {
-  height: 16px;
-  width: 16px;
-  background-color: var(--color-white);
-  border: 0;
-  border-radius: var(--border-radius-default);
-  box-shadow: inset 0 1px 0 0 rgba($color-rich-black, 0.07), 0 0 0 1px tint($color-rich-black, 80%);
-  left: 0;
-  top: 4px;
+input[type="checkbox"] {
+  width: calc(var(--font-size-base) * 1.35);
+  height: calc(var(--font-size-base) * 1.35);
+  outline: 0px;
 }
 
-/* On mouse-over, add a grey background color */
-.lux-checkbox :not([disabled]) + label:hover::before {
-  box-shadow: 0 1px 5px 0 rgba($color-rich-black, 0.07), 0 0 0 1px tint($color-rich-black, 60%);
-}
-
-.lux-checkbox input:checked + label::before {
-  transition: box-shadow 0.2s ease;
-  background-color: var(--color-bleu-de-france);
-  box-shadow: inset 0 0 0 1px var(--color-bleu-de-france), 0 0 0 1px var(--color-bleu-de-france);
-  outline: 0;
-}
-
-/*Checkmark of the fake checkbox*/
-.lux-checkbox label::after {
-  height: 5px;
-  width: 10px;
-  border-left: 2px solid var(--color-white);
-  border-bottom: 2px solid var(--color-white);
-
-  transform: rotate(-45deg);
-
-  left: 3px;
-  top: 7px;
-}
-
-/*Hide the checkmark by default*/
-.lux-checkbox input[type="checkbox"] + label::after {
-  content: none;
-}
-
-/*Unhide on the checked state*/
-.lux-checkbox input[type="checkbox"]:checked + label::after {
-  content: "";
-}
-
-/*Adding focus styles on the outer-box of the fake checkbox*/
-.lux-checkbox input[type="checkbox"]:focus + label::before {
-  transition: box-shadow var(--duration-quickly) ease;
-  box-shadow: inset 0 0 0 1px var(--color-bleu-de-france), 0 0 0 1px var(--color-bleu-de-france);
-}
-
-.lux-inline {
-  display: inline-block;
+input[type="checkbox"]:focus-visible {
+  @include princeton-focus(dark);
 }
 
 .lux-error {

--- a/src/components/LuxInputRadio.vue
+++ b/src/components/LuxInputRadio.vue
@@ -131,6 +131,7 @@ export default {
 @import "../assets/styles/mixins.scss";
 @import "../assets/styles/variables.css";
 @import "../assets/styles/system.scss";
+@import "../assets/styles/focus.scss";
 
 fieldset {
   border: 0;
@@ -138,7 +139,6 @@ fieldset {
 }
 
 .lux-input {
-  @include stack-space(var(--space-small));
   font-weight: var(--font-weight-regular);
   font-family: var(--font-family-text);
   font-size: var(--font-size-base);
@@ -153,82 +153,16 @@ fieldset {
 }
 
 .lux-radio {
-  @include reset;
-  @include stack-space(var(--space-x-small));
   font-family: var(--font-family-text);
   line-height: var(--line-height-base);
-}
-
-.lux-radio input[type="radio"] {
-  @include visually-hidden;
+  display: flex;
 }
 
 .lux-radio label {
-  position: relative;
-  display: inline-block;
-  margin-bottom: var(--space-xx-small);
   cursor: pointer;
-  padding-left: var(--space-base);
-}
-
-.lux-radio label::before,
-.lux-radio label::after {
-  position: absolute;
-  content: "";
-
-  /*Needed for the line-height to take effect*/
-  display: inline-block;
-}
-
-/*Outer box of the fake radio*/
-.lux-radio label::before {
-  height: 16px;
-  width: 16px;
-  background-color: var(--color-white);
-  border: 0;
-  border-radius: var(--border-radius-circle);
-  box-shadow: inset 0 1px 0 0 rgba($color-rich-black, 0.07), 0 0 0 1px tint($color-rich-black, 80%);
-  left: 0;
-  top: 4px;
-}
-
-/* On mouse-over, add a grey background color */
-.lux-radio :not([disabled]) + label:hover::before {
-  box-shadow: 0 1px 5px 0 rgba($color-rich-black, 0.07), 0 0 0 1px tint($color-rich-black, 60%);
-}
-
-.lux-radio input:checked + label::before {
-  transition: box-shadow 0.2s ease;
-  background-color: var(--color-bleu-de-france);
-  box-shadow: inset 0 0 0 1px var(--color-bleu-de-france), 0 0 0 1px var(--color-bleu-de-france);
-  outline: 0;
-}
-
-/*Checkmark of the fake radio*/
-.lux-radio label::after {
-  height: 6px;
-  width: 6px;
-  border-radius: var(--border-radius-circle);
-  background-color: var(--color-white);
-  left: 5px;
-  top: 9px;
-}
-
-/*Hide the checkmark by default*/
-.lux-radio input[type="radio"] + label::after {
-  content: none;
-}
-
-/*Unhide on the checked state*/
-.lux-radio input[type="radio"]:checked + label::after {
-  content: "";
-}
-
-/*Adding focus styles on the outer-box of the fake radio*/
-.lux-radio input[type="radio"]:focus + label::before {
-  transition: box-shadow 0.2s ease;
-  box-shadow: inset 0 0 0 1px var(--color-bleu-de-france), 0 0 0 1px var(--color-bleu-de-france);
-  outline: 0;
+  padding-left: var(--space-xx-small);
+  margin-top: calc(var(--font-size-base) * 0.175);
+  margin-bottom: calc(var(--font-size-base) * 0.175);
 }
 
 .lux-inline {
@@ -238,6 +172,15 @@ fieldset {
 [disabled] + label {
   cursor: not-allowed;
   color: var(--color-grayscale);
+}
+
+input[type="radio"] {
+  width: calc(var(--font-size-base) * 1.35);
+  height: calc(var(--font-size-base) * 1.35);
+}
+
+input[type="radio"]:focus-visible {
+  @include princeton-focus(dark);
 }
 </style>
 


### PR DESCRIPTION
Closes #225

This branch allows the following RSpec test to pass after starting the styleguide locally with `npm run styleguide`:
```
require 'capybara/rspec';

RSpec.configure do |config|
  config.include Capybara::DSL
  Capybara.default_driver = :selenium
end

RSpec.describe 'LuxInputCheckbox' do
 it 'can be checked in capybara' do
  visit 'http://localhost:6060/#/Components?id=luxinputcheckbox'
  check 'In the clouds'
 end
end

RSpec.describe 'LuxInputRadio' do
 it 'can be chosen in capybara' do
  visit 'http://localhost:6060/#/Components?id=luxinputradio'
  choose 'In the clouds'
 end
end
```