### PR TITLE
[Styleguide] Add language of the page to html element

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -55,4 +55,7 @@ module.exports = {
       },
     },
   },
+  template: {
+    lang: "en",
+  },
 }


### PR DESCRIPTION
This resolves a WCAG level A violation (3.1.1 Language of Page).

See [Using the language attribute on the HTML element](https://www.w3.org/WAI/WCAG22/Techniques/html/H57.html) for details

I followed [this configuration example](https://github.com/vue-styleguidist/vue-styleguidist/blob/e4ba2cc8cbc8aa7131a65e8a8e15bf70c4d1bddb/examples/vueds/styleguide.config.js#L21).