### PR TITLE
Add documentation for all slots used in Lux components

### DIFF
--- a/src/components/LuxAlert.vue
+++ b/src/components/LuxAlert.vue
@@ -14,6 +14,7 @@
       role="alert"
     >
       <span>
+        <!-- @slot the alert text -->
         <slot>{{ alertMessage }}</slot>
       </span>
       <button

--- a/src/components/LuxBanner.vue
+++ b/src/components/LuxBanner.vue
@@ -12,6 +12,7 @@
         >
           <span aria-hidden="true">×</span>
         </button>
+        <!-- @slot The content for your banner. -->
         <slot>{{ bannerMessage }}</slot>
       </lux-wrapper>
     </div>

--- a/src/components/LuxCard.vue
+++ b/src/components/LuxCard.vue
@@ -11,6 +11,7 @@
     ]"
     v-bind:style="{ 'max-width': cardPixelWidth + 'px' }"
   >
+    <!-- @slot The heading, media, and other contents of your card.  -->
     <slot></slot>
   </article>
 </template>

--- a/src/components/LuxDisclosure.vue
+++ b/src/components/LuxDisclosure.vue
@@ -21,6 +21,7 @@
       tabindex="-1"
       :style="{ fontSize: fontSize }"
     >
+      <!-- @slot The full content that should be shown when the user opens the disclosure. -->
       <slot></slot>
     </div>
   </div>

--- a/src/components/LuxGridContainer.vue
+++ b/src/components/LuxGridContainer.vue
@@ -1,5 +1,6 @@
 <template>
   <component :is="type" :class="['lux-flex-container', horizontal]">
+    <!-- @slot The grid items that live in your grid container. -->
     <slot />
   </component>
 </template>

--- a/src/components/LuxGridItem.vue
+++ b/src/components/LuxGridItem.vue
@@ -1,5 +1,6 @@
 <template>
   <component :is="type" :class="['lux-col', columns, vertical, { push: offset }, order]">
+    <!-- @slot The content of your grid item. -->
     <slot />
   </component>
 </template>

--- a/src/components/LuxHeading.vue
+++ b/src/components/LuxHeading.vue
@@ -1,5 +1,6 @@
 <template>
   <component :is="level" class="lux-heading" :class="[{ 'lux-hidden': hidden }, size]">
+    <!-- @slot The text of your heading. -->
     <slot />
   </component>
 </template>

--- a/src/components/LuxHyperlink.vue
+++ b/src/components/LuxHyperlink.vue
@@ -4,6 +4,7 @@
     :class="['lux-link', variation, size, underline ? 'lux-link-underline' : '']"
     :target="newTab ? '_blank' : null"
   >
+    <!-- @slot The text of your hyperlink. -->
     <slot />
     <lux-icon-base v-if="newTab" width="14" height="14" icon-name="(opens in new tab)">
       <lux-icon-new-tab></lux-icon-new-tab>

--- a/src/components/LuxInputButton.vue
+++ b/src/components/LuxInputButton.vue
@@ -11,6 +11,7 @@
         <component :is="iconComponent"></component>
       </lux-icon-base>
     </div>
+    <!-- @slot The text of your button. -->
     <slot />
     <div v-if="variation === 'icon'" class="append-icon">
       <lux-icon-base width="18" height="18" :icon-name="icon">

--- a/src/components/LuxLibraryHeader.vue
+++ b/src/components/LuxLibraryHeader.vue
@@ -1,6 +1,7 @@
 <template>
   <component :is="type" :class="['lux-library-header', theme]">
     <lux-wrapper class="lux-header-content" :maxWidth="maxWidth">
+      <!-- @slot A custom logo to display in the Header.  If no logo is provided, it defaults to the Princeton University Library logo. -->
       <slot name="logo">
         <lux-library-logo width="245" height="54" :theme="value(theme)"></lux-library-logo>
       </slot>
@@ -15,6 +16,7 @@
         <span class="abbr-name">{{ abbrName }}</span>
       </a>
       <lux-spacer></lux-spacer>
+      <!-- @slot The content of the header, such as a navigation menu. -->
       <slot />
     </lux-wrapper>
   </component>

--- a/src/components/LuxSearchBox.vue
+++ b/src/components/LuxSearchBox.vue
@@ -1,5 +1,6 @@
 <template>
   <component :is="type" class="lux-search-box">
+    <!-- @slot The input and its button. -->
     <slot />
   </component>
 </template>

--- a/src/components/LuxSpacer.vue
+++ b/src/components/LuxSpacer.vue
@@ -1,5 +1,6 @@
 <template>
   <component :is="type" class="lux-spacer">
+    <!-- @slot Optional: some content that should be spaced. -->
     <slot />
   </component>
 </template>

--- a/src/components/LuxTextStyle.vue
+++ b/src/components/LuxTextStyle.vue
@@ -1,5 +1,6 @@
 <template>
   <component :is="type" :class="['lux-text-style ', variation]">
+    <!-- @slot The text you'd like to style -->
     <slot />
   </component>
 </template>

--- a/src/components/_LuxCardContent.vue
+++ b/src/components/_LuxCardContent.vue
@@ -1,5 +1,6 @@
 <template>
   <component :is="type" class="lux-card-content">
+    <!-- @slot The supplementary conent in your card -->
     <slot></slot>
   </component>
 </template>

--- a/src/components/_LuxCardHeader.vue
+++ b/src/components/_LuxCardHeader.vue
@@ -1,5 +1,6 @@
 <template>
   <component :is="type" class="lux-card-header">
+    <!-- @slot The header content.  You should probably include a LuxHeading component in this slot to provide good document structure. -->
     <slot></slot>
   </component>
 </template>

--- a/src/components/_LuxCardMedia.vue
+++ b/src/components/_LuxCardMedia.vue
@@ -1,5 +1,6 @@
 <template>
   <component :is="type" class="lux-card-media">
+    <!-- @slot the media content or icon you'd like to include in your card -->
     <slot></slot>
   </component>
 </template>

--- a/tests/unit/specs/components/__snapshots__/luxAlert.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/luxAlert.spec.js.snap
@@ -12,6 +12,7 @@ exports[`LuxAlert.vue has the expected html structure 1`] = `
     role="alert"
   >
     <span>
+      <!-- @slot the alert text -->
       
       Here's some info for you.
       

--- a/tests/unit/specs/components/__snapshots__/luxCard.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/luxCard.spec.js.snap
@@ -6,6 +6,7 @@ exports[`LuxCard.vue has the expected html structure 1`] = `
   id="MyCard"
   style="max-width: px;"
 >
+  <!-- @slot The heading, media, and other contents of your card.  -->
   
   
 </article>

--- a/tests/unit/specs/components/__snapshots__/luxDataTable.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/luxDataTable.spec.js.snap
@@ -36,6 +36,7 @@ exports[`LuxDataTable.vue has the expected html structure 1`] = `
           type="button"
         >
           <!--v-if-->
+          <!-- @slot The text of your button. -->
           
           <div
             class="lux-icon"
@@ -95,6 +96,7 @@ exports[`LuxDataTable.vue has the expected html structure 1`] = `
           type="button"
         >
           <!--v-if-->
+          <!-- @slot The text of your button. -->
           
           <div
             class="lux-icon"
@@ -154,6 +156,7 @@ exports[`LuxDataTable.vue has the expected html structure 1`] = `
           type="button"
         >
           <!--v-if-->
+          <!-- @slot The text of your button. -->
           
           <div
             class="lux-icon"
@@ -232,6 +235,7 @@ exports[`LuxDataTable.vue has the expected html structure 1`] = `
             class="lux-link link medium"
             href="https://example.com"
           >
+            <!-- @slot The text of your hyperlink. -->
             
             foo
             

--- a/tests/unit/specs/components/__snapshots__/luxDropdownMenu.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/luxDropdownMenu.spec.js.snap
@@ -9,6 +9,7 @@ exports[`LuxDropdownMenu.vue has the expected html structure 1`] = `
     type="button"
   >
     <!--v-if-->
+    <!-- @slot The text of your button. -->
     
     Dropdown
     

--- a/tests/unit/specs/components/__snapshots__/luxGridContainer.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/luxGridContainer.spec.js.snap
@@ -4,6 +4,7 @@ exports[`GridItem.vue has the expected html structure 1`] = `
 <div
   class="lux-flex-container center"
 >
+  <!-- @slot The grid items that live in your grid container. -->
   
   
 </div>

--- a/tests/unit/specs/components/__snapshots__/luxGridItem.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/luxGridItem.spec.js.snap
@@ -4,6 +4,7 @@ exports[`GridItem.vue has the expected html structure 1`] = `
 <div
   class="lux-col lg-9 sm-6"
 >
+  <!-- @slot The content of your grid item. -->
   
   
 </div>

--- a/tests/unit/specs/components/__snapshots__/luxHeading.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/luxHeading.spec.js.snap
@@ -4,6 +4,7 @@ exports[`LuxHeading.vue has the expected html structure 1`] = `
 <h1
   class="lux-heading h1"
 >
+  <!-- @slot The text of your heading. -->
   
   Here's a heading.
   

--- a/tests/unit/specs/components/__snapshots__/luxHyperlink.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/luxHyperlink.spec.js.snap
@@ -5,6 +5,7 @@ exports[`LuxHyperlink.vue has the expected html structure 1`] = `
   class="lux-link link medium"
   href="https://library.princeton.edu"
 >
+  <!-- @slot The text of your hyperlink. -->
   
   I'll take you places
   

--- a/tests/unit/specs/components/__snapshots__/luxTextStyle.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/luxTextStyle.spec.js.snap
@@ -4,6 +4,7 @@ exports[`LuxTextStyle.vue has the expected html structure 1`] = `
 <p
   class="lux-text-style default"
 >
+  <!-- @slot The text you'd like to style -->
   
   foo
   


### PR DESCRIPTION
I used the [vue stylguidist docs](https://vue-styleguidist.github.io/docs/Documenting.html#slots) to learn how to document these.
The documentation appears in the styleguide, within the PROPS & SLOTS disclosures