### PR TITLE
[LuxAlert] Add a prop to optionally configure how long before it autoclears

### DIFF
--- a/src/components/LuxAlert.vue
+++ b/src/components/LuxAlert.vue
@@ -98,6 +98,15 @@ export default {
       default: false,
     },
     /**
+     * The number of seconds to wait before autoclearing the
+     * notification.  This prop has no effect if autoclear
+     * is not true.
+     */
+    autoclearSeconds: {
+      type: Number,
+      default: 2,
+    },
+    /**
      * User can manually hide the notification.  This emits a dismissed
      * event that you can bind to if needed (for example, if you want to
      * record that the user hid the notification in a database or localStorage)
@@ -121,7 +130,7 @@ export default {
     if (this.autoclear) {
       setTimeout(() => {
         this.show = false
-      }, 2000)
+      }, this.autoclearSeconds * 1000)
     }
   },
   emits: ["dismissed"],

--- a/tests/unit/specs/components/luxAlert.spec.js
+++ b/tests/unit/specs/components/luxAlert.spec.js
@@ -70,15 +70,57 @@ describe("LuxAlert.vue", () => {
     expect(wrapper.vm.show).toBe(false)
   })
 
-  it("should hide after 2 seconds when autoclear is true", async () => {
-    wrapper.setProps({ autoclear: true })
-    await nextTick()
-    const el = wrapper.find(".lux-alert")
-    expect(wrapper.vm.show).toBe(true)
-    // wait 3 seconds and see if it's hidden
-    setTimeout(() => {
+  describe("when autoclear prop is true", () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+      wrapper = mount(LuxAlert, {
+        props: {
+          autoclear: true,
+        },
+      })
+    })
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+    it("should still display after 1 second", () => {
+      expect(wrapper.vm.show).toBe(true)
+
+      // wait 1 second and confirm that it is still there
+      jest.advanceTimersByTime(1000)
+      expect(wrapper.vm.show).toBe(true)
+    })
+    it("should hide after 2 seconds", () => {
+      expect(wrapper.vm.show).toBe(true)
+
+      // wait 3 seconds and see if it's hidden
+      jest.advanceTimersByTime(3000)
       expect(wrapper.vm.show).toBe(false)
-    }, 3000)
+    })
+  })
+
+  describe("when autoclear prop is true and autoclearSeconds is set to 10", () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+      wrapper = mount(LuxAlert, {
+        props: {
+          autoclear: true,
+          autoclearSeconds: 10,
+        },
+      })
+    })
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+    it("should still display after 3 seconds", () => {
+      expect(wrapper.vm.show).toBe(true)
+      jest.advanceTimersByTime(3000)
+      expect(wrapper.vm.show).toBe(true)
+    })
+    it("should be hiddent after 11 seconds", () => {
+      expect(wrapper.vm.show).toBe(true)
+      jest.advanceTimersByTime(11_000)
+      expect(wrapper.vm.show).toBe(false)
+    })
   })
 
   it("has the expected html structure", () => {


### PR DESCRIPTION
By default, if an alert is set to autoclear, it disappears after 2 seconds, which is a very short amount of time to read certain messages!

This commit adds a new prop called autoclearSeconds where you can optionally set this to a higher number.  The use case for this is in the catalog, so we can replace the blacklight/bootstrap alert flash message (which waits 5 seconds before disappearing) with LuxAlert.

Also, refactor the autoclear tests to use jest fake timers, so they don't have to wait all those seconds before running their assertions.