### PR TITLE
Fixes mobile header

### DIFF
--- a/src/components/LuxLibraryHeader.vue
+++ b/src/components/LuxLibraryHeader.vue
@@ -168,13 +168,6 @@ export default {
   }
 }
 
-// .full-logo {
-//   width: 7rem;
-//   @media (min-width: 900px) {
-//       width: 10rem;
-//   }
-// }
-
 .lux-library-logo {
   margin: 0.5rem 0 0.5rem 0.5rem;
   width: 7rem;

--- a/src/components/LuxLibraryHeader.vue
+++ b/src/components/LuxLibraryHeader.vue
@@ -3,7 +3,7 @@
     <lux-wrapper class="lux-header-content" :maxWidth="maxWidth">
       <!-- @slot A custom logo to display in the Header.  If no logo is provided, it defaults to the Princeton University Library logo. -->
       <slot name="logo">
-        <lux-library-logo width="205px" height="40px" :theme="value(theme)"></lux-library-logo>
+        <lux-library-logo :theme="value(theme)"></lux-library-logo>
       </slot>
       <a
         v-if="appName"
@@ -161,7 +161,6 @@ export default {
   align-items: center;
   display: flex;
   padding: 0;
-
   @media (min-width: 900px) {
     flex-direction: row;
     max-width: 1440px;
@@ -169,12 +168,19 @@ export default {
   }
 }
 
+// .full-logo {
+//   width: 7rem;
+//   @media (min-width: 900px) {
+//       width: 10rem;
+//   }
+// }
+
 .lux-library-logo {
-  margin: 0.5rem;
-  width: 205px;
-  height: 40px;
+  margin: 0.5rem 0 0.5rem 0.5rem;
+  width: 7rem;
   @media (min-width: 900px) {
-    margin: 1rem 0rem 1rem 0rem;
+    margin: 1rem !important;
+    width: 10rem !important;
   }
 }
 

--- a/src/components/LuxLibraryLogo.vue
+++ b/src/components/LuxLibraryLogo.vue
@@ -1,8 +1,8 @@
 <template>
   <component :is="type" :class="['lux-library-logo', theme]">
     <a href="https://library.princeton.edu">
-      <lux-logo-library :width="width" :height="height" v-if="theme === 'dark'" class="full-logo" />
-      <lux-logo-library :width="width" :height="height" v-else color="#000000" class="full-logo" />
+      <lux-logo-library v-if="theme === 'dark'" class="full-logo" />
+      <lux-logo-library v-else color="#000000" class="full-logo" />
     </a>
   </component>
 </template>
@@ -34,20 +34,6 @@ export default {
       type: String,
       default: "dark",
     },
-    /*
-     * The width of the logo
-     */
-    width: {
-      type: String,
-      default: "155px",
-    },
-    /*
-     * The height of the logo
-     */
-    height: {
-      type: String,
-      default: "34px",
-    },
   },
   components: {
     LuxLogoLibrary,
@@ -61,7 +47,6 @@ export default {
 @import "../assets/styles/focus.scss";
 
 .lux-library-logo {
-  margin: 1rem 0rem 1rem 0rem;
   a {
     &:focus,
     &:focus-visible {

--- a/src/components/logos/LuxLogoLibrary.vue
+++ b/src/components/logos/LuxLogoLibrary.vue
@@ -1,8 +1,6 @@
 <template>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    :width="width"
-    :height="height"
     viewBox="0 0 440.06 97"
     preserveAspectRatio="xMinYMid"
     aria-labelledby="lux-logo-library"


### PR DESCRIPTION
This is a breaking change as it changes the way the Library svg logo is sized. We should not be sizing svg images via dynamic attributes but should instead size them or their containers with css.

Ref #391 




 