### PR TITLE
[Footer and Header] consistent pul logo size and spacing

### DIFF
--- a/src/assets/styles/variables.css
+++ b/src/assets/styles/variables.css
@@ -109,4 +109,8 @@
   --line-height-small: 1.175;
   --line-height-heading: 1.5;
   --positive-text: #7cb518;
+  --lux-library-logo-width-small: 7rem;
+  --lux-library-logo-width-large: 10rem;
+  --lux-library-logo-margin-small: 0.5rem 0 0.5rem 0.5rem;
+  --lux-library-logo-margin-large: 1rem 1rem 1rem 0;
 }

--- a/src/components/LuxLibraryFooter.vue
+++ b/src/components/LuxLibraryFooter.vue
@@ -125,7 +125,7 @@ export default {
   @media (min-width: 900px) {
     border-right: 1px solid rgba(255, 255, 255, 0.3);
     > div {
-      padding-left: 8px;
+      padding-left: 0.5rem;
     }
   }
 
@@ -136,11 +136,11 @@ export default {
 }
 
 .lux-library-logo {
-  margin: 1rem 1rem 1rem 0;
-  width: 12rem;
+  margin: var(--lux-library-logo-margin-small);
+  width: var(--lux-library-logo-width-small);
   @media (min-width: 900px) {
-    margin: 0 1rem 1rem 0;
-    width: 14rem;
+    margin: var(--lux-library-logo-margin-large);
+    width: var(--lux-library-logo-width-large);
   }
 }
 
@@ -254,10 +254,11 @@ export default {
   flex-direction: column;
   flex-wrap: nowrap;
   align-items: stretch;
-  padding: 0rem 1rem 0rem 1rem;
+  padding-right: 1rem;
 
   @media (min-width: 900px) {
     max-width: 1440px;
+    padding: 0rem 1rem 0rem 1rem;
   }
 }
 

--- a/src/components/LuxLibraryHeader.vue
+++ b/src/components/LuxLibraryHeader.vue
@@ -169,11 +169,12 @@ export default {
 }
 
 .lux-library-logo {
-  margin: 0.5rem 0 0.5rem 0.5rem;
-  width: 7rem;
+  margin: var(--lux-library-logo-margin-small);
+  width: var(--lux-library-logo-width-small);
   @media (min-width: 900px) {
-    margin: 1rem;
-    width: 10rem;
+    margin: var(--lux-library-logo-margin-large);
+    width: var(--lux-library-logo-width-large);
+    margin-left: 0.5rem;
   }
 }
 

--- a/src/components/_LuxLibraryContactInfo.vue
+++ b/src/components/_LuxLibraryContactInfo.vue
@@ -55,6 +55,10 @@ export default {
   font-size: var(--font-size-base);
   line-height: var(--line-height-base);
 
+  @media (max-width: 899px) {
+    margin-left: 0.5rem;
+  }
+
   &.dark {
     color: var(--color-white);
     background-color: var(--color-gray-100);


### PR DESCRIPTION
This commit updates the lux footer's logo so that it always matches the size and spacing of the logo in the header.

Closes #405

Large screen (with the catalog):
![the catalog main screen on a wide screen, the header and footer both have a large pul logo and they are aligned the same way horizontally](https://github.com/user-attachments/assets/adfe94f1-2043-4e6e-a0d6-2f7ae47976a4)
![the catalog main screen on a mobile screen, the header and footer both have a small pul logo and they are aligned the same way horizontally](https://github.com/user-attachments/assets/2cd9af77-8f52-4639-8996-5d6c0c231a87)
