### PR TITLE
[LuxSearchBox] Rounded design

### DIFF
--- a/src/components/LuxSearchBox.vue
+++ b/src/components/LuxSearchBox.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="type" class="lux-search-box">
+  <component :is="type" :class="{ 'lux-search-box': true, rounded: corners === 'rounded' }">
     <!-- @slot The input and its button. -->
     <slot>
       <lux-input-text
@@ -57,6 +57,15 @@ export default {
       type: String,
       default: "query",
     },
+    /**
+     * Whether the corners should be rounded (default)
+     * or square.
+     */
+    corners: {
+      type: String,
+      default: "rounded",
+      validator: value => ["rounded", "square"].includes(value),
+    },
     modelValue: {
       type: String,
     },
@@ -80,7 +89,14 @@ export default {
   background: $color-white;
   margin-bottom: 1rem;
   border: 2px solid #212529;
-  border-radius: 3rem;
+
+  &.rounded {
+    border-radius: 3rem;
+
+    :deep(.lux-button) {
+      border-radius: 0 3rem 3rem 0;
+    }
+  }
 
   &:hover,
   &[hover] {
@@ -127,7 +143,6 @@ export default {
 
   :deep(.lux-button) {
     margin: 0;
-    border-radius: 0 3rem 3rem 0;
 
     &.lux-icon {
       background: var(--color-white);
@@ -145,14 +160,15 @@ export default {
 <docs>
 ```jsx
     <div>
-    <lux-search-box>
+    <lux-search-box corners="square">
         <lux-input-text id="foo" name="value" label="Search" :hide-label="true" placeholder="Find all the things" size="large"></lux-input-text>
         <lux-input-button type="button" variation="icon" size="medium" icon="search"></lux-input-button>
     </lux-search-box>
     </div>
 
     <div>
-      <lux-search-box>
+      <!-- rounded is the default -->
+      <lux-search-box corners="rounded">
       </lux-search-box>
     </div>
 ```

--- a/src/components/LuxSearchBox.vue
+++ b/src/components/LuxSearchBox.vue
@@ -80,6 +80,7 @@ export default {
   background: $color-white;
   margin-bottom: 1rem;
   border: 2px solid #212529;
+  border-radius: 3rem;
 
   &:hover,
   &[hover] {
@@ -100,11 +101,10 @@ export default {
   :deep(.lux-input) {
     flex: 1;
     margin-bottom: 0;
-    font-size: 1rem !important;
     padding: 0.375rem 0.75rem;
-    height: 3rem;
 
     input {
+      font-size: 1.5rem;
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
       border-top-left-radius: 0;
@@ -112,20 +112,31 @@ export default {
     }
   }
 
+  :deep(div.lux-input) {
+    height: 3rem;
+  }
+
+  :deep(input.lux-input) {
+    height: 2.25rem;
+  }
+
   :deep(.default-button) {
-    background-color: $color-princeton-orange-on-white;
-    border-radius: 0px !important;
+    background-color: transparent;
     padding: 12px 15px;
   }
 
   :deep(.lux-button) {
     margin: 0;
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+    border-radius: 0 3rem 3rem 0;
 
     &.lux-icon {
       background: var(--color-white);
       padding: 2px;
+    }
+
+    svg {
+      height: max(24px, 1.5rem);
+      width: max(24px, 1.5rem);
     }
   }
 }


### PR DESCRIPTION
Helps with https://github.com/pulibrary/allsearch_frontend/issues/497

Previously, the LuxSearchBox was not rounded.  As far as I can tell, this component is used only in Approvals, Lockers, and an upcoming branch for Allsearch Frontend.

### Screenshots with the new design

Approvals request search:
![Approvals interface with a prominent search and filter, both have very rounded edges, almost an oval](https://github.com/user-attachments/assets/914d9f2c-95f4-498d-bb30-ff4369535f67)

Allsearch front page (empty)
![empty search box](https://github.com/user-attachments/assets/a7e5707b-6324-4a80-bbb2-3b1bd3f9782f)

Allsearch front page (with a search query)
![search box says robot](https://github.com/user-attachments/assets/99246a5b-5044-4dae-88f3-eb5e60305084)

Allsearch search results page (with a search query)
![search box says robot](https://github.com/user-attachments/assets/19a3232e-2ce2-46f3-8fce-35966b08d32b)
