### PR TITLE
Docs: no longer need to install a specific version of np

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ need to be part of the PULibrary organization on npm.
 
 ```
 npm login
-npm install --global np@9.2.0 # don't add this as a devDependency, otherwise you won't be able to push to npm
+npm install --global np # don't add this as a devDependency, otherwise you won't be able to push to npm
 npm run release
 ```
 


### PR DESCRIPTION
Previously, there was some kind of incompatibility with np version 10 (see #114).  This seems to have been resolved, so we no longer have to install a specific version of np.