### PR TITLE
[LuxIconBase] Add an option to put a circle around the icon

### DIFF
--- a/src/components/icons/LuxIconBase.vue
+++ b/src/components/icons/LuxIconBase.vue
@@ -10,7 +10,11 @@
       role="img"
     >
       <title v-if="iconName" :id="iconTitleId" lang="en">{{ iconName }}</title>
-      <g :fill="iconColor">
+      <circle v-if="circleColor" cx="50%" cy="50%" r="11.8" :fill="circleColor" />
+      <g v-if="circleColor" :fill="iconColor" transform="translate(3.6, 3.6) scale(0.7)">
+        <slot></slot>
+      </g>
+      <g v-else :fill="iconColor">
         <slot></slot>
       </g>
     </svg>
@@ -63,6 +67,12 @@ export default {
       default: "currentColor",
     },
     /**
+     * If set, put the SVG icon in a circle with the specified color.
+     */
+    circleColor: {
+      type: String,
+    },
+    /**
      * Hides decorative icon from screen readers
      */
     iconHide: {
@@ -104,6 +114,10 @@ export default {
   <div>
     <lux-icon-base width="30" height="30" icon-name="file">
       <lux-icon-file></lux-icon-file>
+    </lux-icon-base>
+    <!-- You can also surround the icon in a circle of the color you choose -->
+    <lux-icon-base width="40" height="40" icon-name="person" icon-color="white" circle-color="var(--color-rich-black)">
+      <lux-icon-person></lux-icon-person>
     </lux-icon-base>
   </div>
   ```

--- a/tests/unit/specs/components/__snapshots__/luxDataTable.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/luxDataTable.spec.js.snap
@@ -56,6 +56,7 @@ exports[`LuxDataTable.vue has the expected html structure 1`] = `
               >
                 unsorted
               </title>
+              <!--v-if-->
               <g
                 fill="currentColor"
               >
@@ -116,6 +117,7 @@ exports[`LuxDataTable.vue has the expected html structure 1`] = `
               >
                 unsorted
               </title>
+              <!--v-if-->
               <g
                 fill="currentColor"
               >
@@ -176,6 +178,7 @@ exports[`LuxDataTable.vue has the expected html structure 1`] = `
               >
                 unsorted
               </title>
+              <!--v-if-->
               <g
                 fill="currentColor"
               >


### PR DESCRIPTION
The circle is added if you define the `circleColor` prop.  These are the results of the following example using this patch:

```

    <lux-icon-base width="30"  height="30" icon-name="consulting" icon-color="black">
      <lux-icon-consulting></lux-icon-consulting>
    </lux-icon-base>
    <lux-icon-base width="30"  height="30" icon-name="consulting" icon-color="white" circle-color="blue">
      <lux-icon-consulting></lux-icon-consulting>
    </lux-icon-base>
  
```
![Screenshot 2025-06-20 at 11 31 30 AM](https://github.com/user-attachments/assets/3458aa8c-c436-4dd2-a868-b9ee642c3dac)

Helps with https://github.com/pulibrary/allsearch_frontend/issues/504



