### PR TITLE
[LuxShowMore] Don't display HTML comments as part of the snippet view

### DIFF
--- a/tests/unit/specs/components/luxShowMore.spec.js
+++ b/tests/unit/specs/components/luxShowMore.spec.js
@@ -2,6 +2,13 @@ import { mount } from "@vue/test-utils"
 import LuxShowMore from "@/components/LuxShowMore.vue"
 import { nextTick } from "vue"
 
+function visibleContent(wrapper) {
+  return wrapper
+    .findAll(".lux-show-more-content")
+    .filter(w => w.isVisible())
+    .reduce((text, w) => text + w.text(), "")
+}
+
 describe("LuxShowMore.vue", () => {
   let wrapper
   beforeEach(() => {
@@ -26,8 +33,11 @@ describe("LuxShowMore.vue", () => {
   })
 
   it("shows the truncated text by default", () => {
-    expect(wrapper.text()).toContain("Hello, how is it going?")
-    expect(wrapper.text()).not.toContain("Hello, how is it going? I hope you will read my article.")
+    expect(visibleContent(wrapper)).toContain("…")
+    expect(visibleContent(wrapper)).toContain("Hello, how is it going?")
+    expect(visibleContent(wrapper)).not.toContain(
+      "Hello, how is it going? I hope you will read my article."
+    )
   })
 
   it("has no aria-describedby by default", () => {
@@ -91,5 +101,22 @@ describe("LuxShowMore.vue", () => {
     })
 
     expect(wrapper.find("button").exists()).toBe(false)
+  })
+  it("does not show comments", async () => {
+    wrapper = mount(LuxShowMore, {
+      props: {
+        showLabel: "View Abstract",
+        hideLabel: "Hide Abstract",
+        contentId: "my-disclosure",
+        characterLimit: 20,
+      },
+      slots: {
+        default: "<!-- I should not display -->Good",
+      },
+      attachTo: document.body,
+    })
+
+    expect(wrapper.text()).not.toContain("I should not")
+    expect(wrapper.text()).toContain("Good")
   })
 })


### PR DESCRIPTION
The previous implementation of fullText() recursively traversed the nodes in the slots, looking for any text that might be included in the snippet.  Unfortunately, this approach did not exclude HTML comments (which appeared in the snippet view though they should not), and failed to include text provided by v-html bindings (which should be included).

This approach instead keeps the full text in the DOM, even before the user has pressed the ShowMore button.  When the LuxShowMore is not expanded, it is hidden using display:none, but we can still call textContent on it to retrieve text -- including v-html bindings and excluding html comments -- to construct the snippet.

Helps with https://github.com/pulibrary/allsearch_frontend/issues/508