### PR TITLE
Add a close (x) icon

### DIFF
--- a/src/components/icons/LuxIconClose.vue
+++ b/src/components/icons/LuxIconClose.vue
@@ -1,0 +1,51 @@
+<template>
+  <path
+    stroke="currentColor"
+    stroke-width="3.3"
+    stroke-linecap="round"
+    d="M2 2
+  L22 22
+  M22 2
+  L2 22"
+  />
+</template>
+
+<script>
+/**
+ * Icons are used to visually communicate core parts of the product and
+ * available actions. Please be aware that all elements must have closing tags (not "self-closing").
+ * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
+ */
+export default {
+  name: "LuxIconClose",
+  status: "ready",
+  release: "1.0.0",
+  type: "Element",
+}
+</script>
+
+<docs>
+  ```jsx
+  <div>
+    <!-- you can pass in a smaller `width` and `height` as props -->
+    <lux-icon-base width="12" height="12" icon-name="close" >
+      <lux-icon-close></lux-icon-close>
+    </lux-icon-base>
+
+    <!-- or you can use the default, which is 18 -->
+    <lux-icon-base icon-name="close">
+      <lux-icon-close></lux-icon-close>
+    </lux-icon-base>
+
+    <!-- or make it a little bigger too, with colors :) -->
+    <lux-icon-base width="30" height="30" icon-name="close" icon-color="red">
+      <lux-icon-close></lux-icon-close>
+    </lux-icon-base>
+
+    <!-- or in a circle -->
+    <lux-icon-base width="30" height="30" icon-name="close" icon-color="white" circle-color="purple">
+      <lux-icon-close></lux-icon-close>
+    </lux-icon-base>
+  </div>
+  ```
+</docs>

--- a/src/components/icons/index.js
+++ b/src/components/icons/index.js
@@ -8,6 +8,7 @@ import LuxIconAscending from "./LuxIconAscending.vue"
 import LuxIconBase from "./LuxIconBase.vue"
 import LuxIconBookmark from "./LuxIconBookmark.vue"
 import LuxIconClock from "./LuxIconClock.vue"
+import LuxIconClose from "./LuxIconClose.vue"
 import LuxIconConsulting from "./LuxIconConsulting.vue"
 import LuxIconDelivery from "./LuxIconDelivery.vue"
 import LuxIconDenied from "./LuxIconDenied.vue"
@@ -57,6 +58,7 @@ export {
   LuxIconBase,
   LuxIconBookmark,
   LuxIconClock,
+  LuxIconClose,
   LuxIconConsulting,
   LuxIconDelivery,
   LuxIconDenied,


### PR DESCRIPTION
Preview from the style guide:
<img width="271" alt="x icons with rounded corners, in various sizes and colors" src="https://github.com/user-attachments/assets/2a1a7e4f-73ef-4bef-861f-39aa6f7e6e8d" />

Helps with https://github.com/pulibrary/orangelight/issues/4927