### PR TITLE
Use CSS, rather than SASS, variables for font family in components

### DIFF
--- a/src/components/LuxInputButton.vue
+++ b/src/components/LuxInputButton.vue
@@ -158,7 +158,7 @@ export default {
 
 .lux-button {
   @include inset-space($space-small);
-  font-family: $font-family-text;
+  font-family: var(--font-family-text);
   font-size: $font-size-base;
   line-height: $line-height-small;
   border: 0;

--- a/src/components/LuxMenuBar.vue
+++ b/src/components/LuxMenuBar.vue
@@ -429,7 +429,7 @@ export default {
 
 .lux-main-menu {
   @include stack-space($space-base);
-  font-family: $font-family-text;
+  font-family: var(--font-family-text);
   font-size: var(--font-size-base);
   line-height: $line-height-base;
   width: 100%;
@@ -443,7 +443,7 @@ export default {
 
   a,
   .lux-submenu-toggle {
-    font-family: $font-family-text;
+    font-family: var(--font-family-text);
     background-color: transparent;
     border: 0;
     line-height: 1;


### PR DESCRIPTION
This allows a local application to customize the font used in Lux components with a simple CSS rule like:

```
.lux {
  --font-family-heading: 'Libre Franklin', Helvetica, Arial, sans-serif;
}
```

We'd like to do this customization in Orangelight, since [Libre Franklin is a newer recommendation from the branding office](https://drive.google.com/drive/folders/1eBLLEU5dPZbF-1A_MNS5dYIN5gLrOzJE) and it is a variable font.