### PR TITLE
[LuxAutocompleteInput] Announce the current selection when navigating using arrow keys

### DIFF
--- a/src/components/LuxAutocompleteInput.vue
+++ b/src/components/LuxAutocompleteInput.vue
@@ -4,6 +4,7 @@
     <div class="lux-autocomplete-input">
       <input
         id="displayInput"
+        role="combobox"
         autocomplete="off"
         ref="autoComplete"
         type="text"
@@ -11,13 +12,14 @@
         @click="onChange"
         @focus="onChange"
         v-model="search"
-        @keydown.down="onArrowDown"
-        @keydown.up="onArrowUp"
+        @keydown.down.prevent="onArrowDown"
+        @keydown.up.prevent="onArrowUp"
         @keydown.enter="onEnter"
         @keydown.esc="onEscape"
         @keydown.tab="onEscape"
         @blur="onEscape"
         :required="required"
+        :aria-activedescendant="ariaActiveDescendant"
       />
       <ul v-show="isOpen" class="lux-autocomplete-results">
         <li class="loading" v-if="isLoading">Loading results...</li>
@@ -28,6 +30,7 @@
           @click="setResult(result)"
           class="lux-autocomplete-result"
           :class="{ 'is-active': i === arrowCounter }"
+          :id="'lux-autocomplete-' + this.componentId + 'result-' + i"
         >
           {{ result }}
         </li>
@@ -38,6 +41,8 @@
 </template>
 
 <script>
+import { useId } from "vue"
+
 /**
  * InputAutocomplete is a cross between a text input and select input.
  * This component is used to offer users suggested values that
@@ -221,6 +226,15 @@ export default {
       }
     },
   },
+  computed: {
+    ariaActiveDescendant() {
+      if (this.arrowCounter < 0) {
+        return null
+      } else {
+        return `lux-autocomplete-${this.componentId}result-${this.arrowCounter}`
+      }
+    },
+  },
   created() {
     this.setResult(this.defaultValue)
   },
@@ -236,6 +250,12 @@ export default {
   },
   unmounted() {
     document.removeEventListener("click", this.handleClickOutside)
+  },
+  setup() {
+    // A unique id that identifies this specific instance of the component, so that DOM ids are unique
+    // even if you have many autocompletes on a screen
+    const componentId = useId()
+    return { componentId }
   },
 }
 </script>

--- a/tests/unit/specs/components/__snapshots__/luxAutocompleteInput.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/luxAutocompleteInput.spec.js.snap
@@ -11,6 +11,7 @@ exports[`InputAutocomplete.vue has the expected html structure 1`] = `
     <input
       autocomplete="off"
       id="displayInput"
+      role="combobox"
       type="text"
     />
     <ul
@@ -20,6 +21,7 @@ exports[`InputAutocomplete.vue has the expected html structure 1`] = `
       
       <li
         class="lux-autocomplete-result"
+        id="lux-autocomplete-v-0result-0"
       >
         Banana
       </li>

--- a/tests/unit/specs/components/luxAutocompleteInput.spec.js
+++ b/tests/unit/specs/components/luxAutocompleteInput.spec.js
@@ -40,6 +40,20 @@ describe("InputAutocomplete.vue", () => {
     // expect(wrapper.vm.arrowCounter).toBe(1)
   })
 
+  it("can announce the currently selected item via aria-activedescendant", async () => {
+    const input = wrapper.find("#displayInput")
+    input.trigger("focus")
+    // Enter the first few letters of pineapple
+    input.setValue("pin")
+    // Select pineapple
+    input.trigger("keydown.down")
+    await nextTick()
+
+    const pineappleItem = wrapper.find(".lux-autocomplete-result")
+    expect(pineappleItem.text()).toEqual("Pineapple")
+    expect(input.attributes("aria-activedescendant")).toEqual(pineappleItem.attributes("id"))
+  })
+
   it("hitting enter resets the counter and closes the dropdown", () => {
     wrapper.setData({ isOpen: true })
     wrapper.setData({ arrowCounter: 0 })


### PR DESCRIPTION
Prior to this commit, if you:
1. Open Mac VoiceOver
2. Go to the styleguide demo for the LuxAutocompleteInput component
3. Try navigating through the fruits using your arrow keys

VoiceOver will be completely silent as you move up and down, other than the occassional "bump" sound effect as your cursor moves around in the input field.

This commit uses `aria-activedescendant` to let voiceover know which item to announce as the user moves around through the list of fruits. It changes the role of the input to `combobox` (`aria-activedescendant` is only valid on certain roles, `combobox` is one of the valid roles). It also prevents the default behavior of the up and down arrows (moving to the start and end of the input), since that causes an annoying bumping sound that interrupts all the fruit announcements from the autocomplete entries.

I have also confirmed this fix on NVDA with Firefox.

Closes #352