### PR TITLE
[LuxAutocompleteInput] Get placeholder prop working

### DIFF
--- a/src/components/LuxAutocompleteInput.vue
+++ b/src/components/LuxAutocompleteInput.vue
@@ -20,6 +20,7 @@
         @blur="onEscape"
         :required="required"
         :aria-activedescendant="ariaActiveDescendant"
+        :placeholder="placeholder"
       />
       <ul v-show="isOpen" class="lux-autocomplete-results">
         <li class="loading" v-if="isLoading">Loading results...</li>
@@ -72,7 +73,7 @@ export default {
      */
     placeholder: {
       type: String,
-      default: "",
+      default: null,
     },
     /**
      * The default value for the form input field.

--- a/tests/unit/specs/components/luxAutocompleteInput.spec.js
+++ b/tests/unit/specs/components/luxAutocompleteInput.spec.js
@@ -136,6 +136,20 @@ describe("InputAutocomplete.vue", () => {
     expect(wrapper.emitted().input[1]).toEqual(["Code4lib 2025"])
   })
 
+  describe("placeholder", () => {
+    it("displays no placeholder by default", () => {
+      expect(wrapper.find("input").attributes("placeholder")).toBeFalsy()
+    })
+
+    it("displays the provided placeholder if supplied as a prop", async () => {
+      wrapper.setProps({ placeholder: "Please choose your favorite one!" })
+      await nextTick()
+      expect(wrapper.find("input").attributes("placeholder")).toEqual(
+        "Please choose your favorite one!"
+      )
+    })
+  })
+
   it("has the expected html structure", () => {
     expect(wrapper.element).toMatchSnapshot()
   })


### PR DESCRIPTION
This component has a placeholder prop, but prior to this commit, it was not used.  This commit uses it as the input's placeholder if present.

Helps with #486, since that component will need a placeholder