### PR TITLE
Address warnings that happen during npm run test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7052,9 +7052,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001723",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001723.tgz",
-      "integrity": "sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==",
+      "version": "1.0.30001753",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001753.tgz",
+      "integrity": "sha512-Bj5H35MD/ebaOV4iDLqPEtiliTN29qkGtEHCwawWn4cYm+bPJM2NsaP30vtZcnERClMzp52J4+aw2UNbK4o+zw==",
       "dev": true,
       "funding": [
         {

--- a/src/components/LuxMediaImage.vue
+++ b/src/components/LuxMediaImage.vue
@@ -20,6 +20,9 @@
 </template>
 
 <script>
+import LuxIconBase from "./icons/LuxIconBase.vue"
+import LuxIconFile from "./icons/LuxIconFile.vue"
+
 /**
  * Media-Image is a component that is used to display an image,
  * or an icon if the image can't be resolved.
@@ -69,6 +72,10 @@ export default {
     contain: {
       type: Boolean,
       default: false,
+    },
+    components: {
+      LuxIconBase,
+      LuxIconFile,
     },
   },
 }

--- a/src/components/LuxTextStyle.vue
+++ b/src/components/LuxTextStyle.vue
@@ -39,7 +39,7 @@ export default {
       type: String,
       default: "var(--color-rich-black)",
       validator: value => {
-        return value.match(/(grey-dark|red|green|blue)/)
+        return value.match(/(var\(--color-rich-black\)|grey-dark|red|green|blue)/)
       },
     },
   },

--- a/tests/unit/specs/components/luxMediaImage.spec.js
+++ b/tests/unit/specs/components/luxMediaImage.spec.js
@@ -42,6 +42,12 @@ describe("LuxMediaImage.vue", () => {
         cover: false,
         contain: true,
       },
+      global: {
+        stubs: {
+          "lux-icon-base": true,
+          "lux-icon-file": true,
+        },
+      },
     })
     expect(wrapper2.find('[name="pul-icon-file"]').exists()).toBe(false)
     expect(wrapper2.find("img").exists()).toBe(true)


### PR DESCRIPTION
Running tests has gotten a little noisy with warnings.  This commit clears the following warnings:

```
console.warn
      [Vue warn]: Invalid prop: custom validator check failed for prop "color".
        at <LuxTextStyle ref="VTU_COMPONENT" >
        at <VTUROOT>

       6 |
       7 |   beforeEach(() => {
    >  8 |     wrapper = mount(LuxTextStyle, {
         |                    ^
       9 |       slots: {
      10 |         default: "foo",
      11 |       },
```

```
console.warn
      [Vue warn]: Failed to resolve component: lux-icon-base
      If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement.
        at <LuxMediaImage src="https://picsum.photos/400/300/?random" height="medium" alt="alt text"  ... >
        at <VTUROOT>
```

```
console.warn
      [Vue warn]: Failed to resolve component: lux-icon-file
      If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement.
        at <LuxMediaImage src="https://picsum.photos/400/300/?random" height="medium" alt="alt text"  ... >
        at <VTUROOT>
```

```
Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```