### PR TITLE
[LuxInputMultiselect] explicitly declare the dependency on LuxBadge

### DIFF
--- a/src/components/LuxInputMultiselect.vue
+++ b/src/components/LuxInputMultiselect.vue
@@ -53,6 +53,7 @@
 </template>
 <script setup>
 import LuxAutocompleteInput from "./LuxAutocompleteInput.vue"
+import LuxBadge from "./LuxBadge.vue"
 import LuxIconBase from "./icons/LuxIconBase.vue"
 import LuxIconSearch from "./icons/LuxIconSearch.vue"
 import LuxInputButton from "./LuxInputButton.vue"
@@ -136,9 +137,7 @@ function removeItem(item) {
 
 async function findNewItems(query) {
   if (!(props.asyncLoadItemsFunction === undefined) && !(props.asyncLoadItemsFunction === null)) {
-    let resultProxy = await props.asyncLoadItemsFunction(query)
-    let result = JSON.parse(JSON.stringify(resultProxy))
-    allCurrentItems.value = result
+    allCurrentItems.value = await props.asyncLoadItemsFunction(query)
   }
 }
 </script>


### PR DESCRIPTION
If this dependency is not explicitly declared, you get this warning if you try to import LuxInputMultiselect into another Vue component:

```
[Vue warn]: Failed to resolve component: lux-badge
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement.
```

Also, cleanup an unneeded JSON.stringify/JSON.parse experiment