### PR TITLE
[LuxAutocompleteInput] Allow items to be scrolled into view by the arrow keys

### DIFF
--- a/src/components/LuxAutocompleteInput.vue
+++ b/src/components/LuxAutocompleteInput.vue
@@ -199,13 +199,15 @@ export default {
       }
     },
     onArrowDown() {
-      if (this.arrowCounter < this.results.length) {
+      if (this.arrowCounter < this.results.length - 1) {
         this.arrowCounter = this.arrowCounter + 1
+        this.scroll_to_active_item()
       }
     },
     onArrowUp() {
       if (this.arrowCounter > 0) {
         this.arrowCounter = this.arrowCounter - 1
+        this.scroll_to_active_item()
       }
     },
     onEnter() {
@@ -233,6 +235,11 @@ export default {
        * Emitted when the user selects an "official" value from the list of supplied terms
        */
       this.$emit("selected", id)
+    },
+    scroll_to_active_item() {
+      var item_id = `lux-autocomplete-${this.componentId}result-${this.arrowCounter}`
+      var item = document.getElementById(item_id)
+      item.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "start" })
     },
   },
   watch: {

--- a/tests/unit/specs/components/luxAutocompleteInput.spec.js
+++ b/tests/unit/specs/components/luxAutocompleteInput.spec.js
@@ -6,6 +6,7 @@ describe("InputAutocomplete.vue", () => {
   let wrapper
 
   beforeEach(() => {
+    Element.prototype.scrollIntoView = jest.fn()
     wrapper = mount(LuxAutocompleteInput, {
       propsData: {
         id: "foo",
@@ -16,6 +17,8 @@ describe("InputAutocomplete.vue", () => {
           { id: 2, label: "Banana" },
           { id: 3, label: "Mango" },
           { id: 4, label: "Pineapple" },
+          { id: 5, label: "Passion Fruit" },
+          { id: 6, label: "Star Fruit" },
         ],
         focused: true,
       },
@@ -32,15 +35,29 @@ describe("InputAutocomplete.vue", () => {
     expect(wrapper.vm.inputValue).toBe(2)
   })
 
-  it("keyboard navigation works", () => {
-    wrapper.find("input.displayInput").trigger("focus")
+  it("keyboard navigation works", async () => {
+    const input = wrapper.find("input.displayInput")
+
+    input.trigger("focus")
+    input.setValue("")
+    await nextTick()
     expect(wrapper.vm.arrowCounter).toBe(-1)
-    wrapper.find("input.displayInput").trigger("keydown.down")
+    input.trigger("keydown.down")
     expect(wrapper.vm.arrowCounter).toBe(0)
-    wrapper.find("input.displayInput").trigger("keydown.down")
+    input.trigger("keydown.down")
     expect(wrapper.vm.arrowCounter).toBe(1)
-    wrapper.find("input.displayInput").trigger("keydown.up")
+    input.trigger("keydown.up")
     expect(wrapper.vm.arrowCounter).toBe(0)
+    input.trigger("keydown.down")
+    expect(wrapper.vm.arrowCounter).toBe(1)
+    input.trigger("keydown.down")
+    expect(wrapper.vm.arrowCounter).toBe(2)
+    input.trigger("keydown.down")
+    expect(wrapper.vm.arrowCounter).toBe(3)
+    input.trigger("keydown.down")
+    expect(wrapper.vm.arrowCounter).toBe(4)
+    await nextTick()
+    expect(Element.prototype.scrollIntoView.mock.calls).toHaveLength(7)
   })
 
   it("can announce the currently selected item via aria-activedescendant", async () => {


### PR DESCRIPTION
Arrow keys currently just scroll off the view port without showing the new options.

See recording https://princeton.zoom.us/rec/share/OrjkO36JR-bdefhyJjYXl5ZsqAxa4DVJF_Db_l19wSt86TCxtr3KvRFLkRRaalhG.motee7B5D7bADU2U