### PR TITLE
Remove repeated definitions of CSS variables from built CSS

### DIFF
--- a/src/components/LuxAlert.vue
+++ b/src/components/LuxAlert.vue
@@ -138,7 +138,6 @@ export default {
 </script>
 
 <style lang="scss">
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/mixins.scss" as *;
 
 .lux-alert-fullscreen {

--- a/src/components/LuxAutocompleteInput.vue
+++ b/src/components/LuxAutocompleteInput.vue
@@ -292,7 +292,6 @@ export default {
 
 <style lang="scss">
 @use "/src/assets/styles/spacing.scss" as *;
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/system.scss" as *;
 // Design Tokens with local scope
 $color-placeholder: tint($color-grayscale, 50%);

--- a/src/components/LuxBanner.vue
+++ b/src/components/LuxBanner.vue
@@ -84,7 +84,6 @@ export default {
 
 <style lang="scss">
 @use "/src/assets/styles/mixins.scss" as *;
-@use "/src/assets/styles/variables.css" as *;
 
 .lux-banner-fullscreen {
   position: fixed;

--- a/src/components/LuxCard.vue
+++ b/src/components/LuxCard.vue
@@ -94,7 +94,6 @@ export default {
 </script>
 
 <style lang="scss">
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/mixins.scss" as *;
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/focus.scss" as *;

--- a/src/components/LuxDataTable.vue
+++ b/src/components/LuxDataTable.vue
@@ -267,7 +267,6 @@ export default {
 <style lang="scss" scoped>
 @use "sass:color";
 @use "/src/assets/styles/system.scss" as *;
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/spacing.scss" as *;
 
 .lux-data-table {

--- a/src/components/LuxDatePicker.vue
+++ b/src/components/LuxDatePicker.vue
@@ -283,7 +283,6 @@ function stringSeemsLikeDateRange(possibleRange) {
 
 <style lang="scss">
 @use "/src/assets/styles/spacing.scss" as *;
-@use "/src/assets/styles/variables.css" as *;
 .lux-date-picker {
   @include stack-space(var(--space-small));
 }

--- a/src/components/LuxDropdownMenu.vue
+++ b/src/components/LuxDropdownMenu.vue
@@ -129,7 +129,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/system.scss" as *;
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/mixins.scss" as *;

--- a/src/components/LuxHeading.vue
+++ b/src/components/LuxHeading.vue
@@ -52,7 +52,6 @@ export default {
 </script>
 
 <style lang="scss">
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/mixins.scss" as *;
 @use "/src/assets/styles/spacing.scss" as *;
 

--- a/src/components/LuxHyperlink.vue
+++ b/src/components/LuxHyperlink.vue
@@ -79,7 +79,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/spacing.scss" as *;
 
 .lux-link {

--- a/src/components/LuxInputCheckbox.vue
+++ b/src/components/LuxInputCheckbox.vue
@@ -129,7 +129,6 @@ export default {
 <style lang="scss" scoped>
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/mixins.scss" as *;
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/focus.scss" as *;
 
 fieldset {

--- a/src/components/LuxInputRadio.vue
+++ b/src/components/LuxInputRadio.vue
@@ -129,7 +129,6 @@ export default {
 <style lang="scss" scoped>
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/mixins.scss" as *;
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/focus.scss" as *;
 
 fieldset {

--- a/src/components/LuxInputSelect.vue
+++ b/src/components/LuxInputSelect.vue
@@ -185,7 +185,6 @@ export default {
 
 <style lang="scss" scoped>
 @use "sass:color";
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/mixins.scss" as mi;
 @use "/src/assets/styles/system.scss" as *;

--- a/src/components/LuxInputText.vue
+++ b/src/components/LuxInputText.vue
@@ -308,7 +308,6 @@ export default {
 
 <style lang="scss" scoped>
 @use "sass:color";
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/mixins.scss" as mi;
 @use "/src/assets/styles/system.scss" as *;

--- a/src/components/LuxLibraryFooter.vue
+++ b/src/components/LuxLibraryFooter.vue
@@ -117,7 +117,6 @@ export default {
 <style lang="scss" scoped>
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/mixins.scss" as *;
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/focus.scss" as *;
 
 .contact-info-layout {

--- a/src/components/LuxLibraryHeader.vue
+++ b/src/components/LuxLibraryHeader.vue
@@ -95,7 +95,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/mixins.scss" as *;
 @use "/src/assets/styles/focus.scss" as *;
 /**

--- a/src/components/LuxLibraryLogo.vue
+++ b/src/components/LuxLibraryLogo.vue
@@ -42,7 +42,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/focus.scss" as *;
 @use "/src/assets/styles/media_queries.scss" as *;
 

--- a/src/components/LuxLoader.vue
+++ b/src/components/LuxLoader.vue
@@ -48,7 +48,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/system.scss" as *;
 

--- a/src/components/LuxMenuBar.vue
+++ b/src/components/LuxMenuBar.vue
@@ -277,7 +277,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/system.scss" as *;
 @use "/src/assets/styles/media_queries.scss" as mq;

--- a/src/components/LuxSpecialCollectionsFooter.vue
+++ b/src/components/LuxSpecialCollectionsFooter.vue
@@ -125,7 +125,6 @@ export default {
 <style lang="scss" scoped>
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/mixins.scss" as *;
-@use "/src/assets/styles/variables.css" as *;
 
 .lux-special-collections-footer {
   @include reset;

--- a/src/components/LuxTag.vue
+++ b/src/components/LuxTag.vue
@@ -106,7 +106,6 @@ export default {
 @use "sass:color";
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/system.scss" as *;
-@use "/src/assets/styles/variables.css" as *;
 
 .lux-tag {
   @include stack-space($space-base);

--- a/src/components/LuxTextStyle.vue
+++ b/src/components/LuxTextStyle.vue
@@ -48,7 +48,6 @@ export default {
 
 <style lang="scss">
 @use "/src/assets/styles/spacing.scss" as *;
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/system.scss" as *;
 $positive-text: #7cb518;
 

--- a/src/components/LuxUniversityFooter.vue
+++ b/src/components/LuxUniversityFooter.vue
@@ -100,7 +100,6 @@ export default {
 
 <style lang="scss" scoped>
 @use "/src/assets/styles/spacing.scss" as *;
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/system.scss" as *;
 @use "/src/assets/styles/focus.scss" as *;
 

--- a/src/components/_LuxLibraryContactInfo.vue
+++ b/src/components/_LuxLibraryContactInfo.vue
@@ -44,7 +44,6 @@ export default {
 <style lang="scss" scoped>
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/mixins.scss" as *;
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/focus.scss" as *;
 
 .lux-library-contact {

--- a/src/components/_LuxLibraryContactInfoOld.vue
+++ b/src/components/_LuxLibraryContactInfoOld.vue
@@ -64,7 +64,6 @@ export default {
 <style lang="scss" scoped>
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/mixins.scss" as *;
-@use "/src/assets/styles/variables.css" as *;
 
 .lux-library-contact {
   @include reset;

--- a/src/components/_LuxSubscribeNewsletter.vue
+++ b/src/components/_LuxSubscribeNewsletter.vue
@@ -69,7 +69,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/mixins.scss" as *;
 
 .lux-subscribe-newsletter {

--- a/src/components/_LuxUniversityAccessibility.vue
+++ b/src/components/_LuxUniversityAccessibility.vue
@@ -40,7 +40,6 @@ export default {
 <style lang="scss" scoped>
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/mixins.scss" as *;
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/focus.scss" as *;
 
 .lux-accessibility {

--- a/src/components/_LuxUniversityAccessibilityOld.vue
+++ b/src/components/_LuxUniversityAccessibilityOld.vue
@@ -28,7 +28,6 @@ export default {
 <style lang="scss" scoped>
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/mixins.scss" as *;
-@use "/src/assets/styles/variables.css" as *;
 
 .lux-accessibility {
   @include reset;

--- a/src/components/_LuxUniversityCopyright.vue
+++ b/src/components/_LuxUniversityCopyright.vue
@@ -33,7 +33,6 @@ export default {
 <style lang="scss" scoped>
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/mixins.scss" as *;
-@use "/src/assets/styles/variables.css" as *;
 
 .lux-copyright {
   @include reset;

--- a/src/components/_LuxUniversityCopyrightOld.vue
+++ b/src/components/_LuxUniversityCopyrightOld.vue
@@ -29,7 +29,6 @@ export default {
 <style lang="scss" scoped>
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/mixins.scss" as *;
-@use "/src/assets/styles/variables.css" as *;
 
 .lux-copyright {
   @include reset;

--- a/src/components/_LuxUniversityPrivacyNotice.vue
+++ b/src/components/_LuxUniversityPrivacyNotice.vue
@@ -40,7 +40,6 @@ export default {
 <style lang="scss" scoped>
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/mixins.scss" as *;
-@use "/src/assets/styles/variables.css" as *;
 @use "/src/assets/styles/focus.scss" as *;
 
 .lux-privacy-notice {

--- a/src/components/icons/LuxIconBase.vue
+++ b/src/components/icons/LuxIconBase.vue
@@ -98,7 +98,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import "../../assets/styles/variables.css";
 .lux-icon {
   display: inline-flex;
   align-self: center;

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@
 import * as components from "./components"
 import VCalendar from "v-calendar"
 import "v-calendar/style.css"
+import "./assets/styles/variables.css"
 
 export default {
   // Vue plugins must expose an install() method, see

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -43,6 +43,7 @@ module.exports = {
   exampleMode: "expand",
   enhancePreviewApp: path.join(__dirname, "styleguide_vue_app.js"),
   version: process.env.npm_package_version,
+  require: [path.join(__dirname, "src/assets/styles/variables.css")],
   theme: {
     fontFamily: {
       base: "var(--font-family-text)",


### PR DESCRIPTION
Prior to this commit, we imported the CSS variables into each component that needed them. This allowed the components to display with the correct CSS, but came at a cost: in the built CSS, the CSS variable definitions were repeated 24 times, once for each component that used them.

This commit takes a different approach: we do not import the CSS variables into each component, but rather load the variables once.  For the styleguide display, this takes place as part of the styleguide configuration.  For the build CSS, this happens via an import in index.js.

This reduces the size of the compiled CSS from 234 kB to 128 kB.