### PR TITLE
Forward mixins and variables used by pulfalight

### DIFF
--- a/src/assets/styles/style.scss
+++ b/src/assets/styles/style.scss
@@ -1,5 +1,5 @@
 @use "../styles/media_queries";
 @use "../styles/mixins";
-@use "../styles/spacing";
-@use "../styles/system";
+@forward "../styles/spacing";
+@forward "../styles/system";
 @use "../styles/focus";


### PR DESCRIPTION
Without forward, the vars and mixins aren't available downstream.
However, if we forward everything we get errors about duplicate exports.
So we just did the 2 we knew we needed for now.

The issue was introduced in the 6.2.0 release, #427

advances pulibrary/pulfalight#1661
