### PR TITLE
Use standard CSS font-size instead of calculating using responsive-font mixin

### DIFF
--- a/src/components/LuxDataTable.vue
+++ b/src/components/LuxDataTable.vue
@@ -283,12 +283,7 @@ export default {
     font-weight: var(--font-weight-bold);
     font-family: var(--font-family-text);
     line-height: var(--line-height-heading);
-    @include responsive-font(
-      2vw,
-      $font-size-x-large-min,
-      $font-size-x-large-max,
-      $font-size-x-large
-    );
+    font-size: var(--font-size-x-large);
   }
 
   thead {

--- a/src/components/LuxHeading.vue
+++ b/src/components/LuxHeading.vue
@@ -70,28 +70,28 @@ export default {
 .h1 {
   letter-spacing: var(--letter-spacing-x-small);
   font-weight: var(--font-weight-bold);
-  @include responsive-font(3vw, 1.602em, 3.157em, 64px);
+  font-size: var(--font-size-xxx-large);
 }
 
 .h2 {
   letter-spacing: var(--letter-spacing-small);
   font-weight: var(--font-weight-bold);
-  @include responsive-font(2.5vw, 1.602em, 3.157em, 42px);
+  font-size: 42px;
 }
 
 .h3 {
   font-weight: var(--font-weight-bold);
-  @include responsive-font(2vw, 1.266em, 1.777em, 36px);
+  font-size: var(--font-size-x-large);
 }
 
 .h4 {
   font-weight: var(--font-weight-semi-bold);
-  @include responsive-font(1.5vw, 1.266em, 1.777em, 36px);
+  font-size: var(--font-size-x-large);
 }
 
 .h5 {
   font-weight: var(--font-weight-semi-bold);
-  @include responsive-font(1vw, 1em, 1.125em, 16px);
+  font-size: var(--font-size-base);
 }
 
 .h6 {


### PR DESCRIPTION
When trying to upgrade vite in orangelight, we got the error:

```
[plugin vite:css-post]
SyntaxError: [lightningcss minify] Invalid media query
1  |  ...ight-heading);font-size:2vw;font-size:36px}@media (max-width: calc(1.266em/strip-unit(2vw)*100)){.lux-data-table c...
   |                                                                 ^
2  |
3  |  @keyframes fadeIn {
    at Module.<anonymous> (/Users/sandbergj/repos/orangelight/node_modules/lightningcss/node/index.js:56:14)
    at minifyCSS (file:///Users/sandbergj/repos/orangelight/node_modules/vite/dist/node/chunks/node.js:21304:59)
    at async finalizeCss (file:///Users/sandbergj/repos/orangelight/node_modules/vite/dist/node/chunks/node.js:21149:36)
    at async Promise.all (index 1)
    at async Object.run (file:///Users/sandbergj/repos/orangelight/node_modules/vite/dist/node/chunks/node.js:2435:22)
    at async PluginContextImpl.renderChunk (file:///Users/sandbergj/repos/orangelight/node_modules/vite/dist/node/chunks/node.js:20685:19)
    at async plugin (file:///Users/sandbergj/repos/orangelight/node_modules/rolldown/dist/shared/bindingify-input-options-DbbBhzky.mjs:1277:16)
    at async plugin.<computed> (file:///Users/sandbergj/repos/orangelight/node_modules/rolldown/dist/shared/bindingify-input-options-DbbBhzky.mjs:1612:12)
    at aggregateBindingErrorsIntoJsError (file:///Users/sandbergj/repos/orangelight/node_modules/rolldown/dist/shared/error-DL-e8-oE.mjs:48:18)
    at unwrapBindingResult (file:///Users/sandbergj/repos/orangelight/node_modules/rolldown/dist/shared/error-DL-e8-oE.mjs:18:128)
    at #build (file:///Users/sandbergj/repos/orangelight/node_modules/rolldown/dist/shared/rolldown-build-DSxL8qiP.mjs:3317:34)
    at async buildEnvironment (file:///Users/sandbergj/repos/orangelight/node_modules/vite/dist/node/chunks/node.js:33018:64)
    at async Object.build (file:///Users/sandbergj/repos/orangelight/node_modules/vite/dist/node/chunks/node.js:33440:19)
    at async Object.buildApp (file:///Users/sandbergj/repos/orangelight/node_modules/vite/dist/node/chunks/node.js:33437:153)
    at async CAC.<anonymous> (file:///Users/sandbergj/repos/orangelight/node_modules/vite/dist/node/cli.js:778:3) {
  errors: [Getter/Setter]
}
error Command failed with exit code 1.

pid 24325 exit 1
Build with Vite failed! ❌
```

Using a standard CSS `font-size` instead of the SASS `responsive-font` mixin has the same effect on all reasonable screen sizes, and allows us to avoid this issue.