### PR TITLE
vue pseudo selector :deep needs to be in a <style scoped> tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@playwright/test": "^1.59.1",
         "@rollup/plugin-replace": "^6.0.2",
         "@types/node": "^24.10.0",
-        "@vitejs/plugin-vue": "^5.0.0",
+        "@vitejs/plugin-vue": "^6.0.6",
         "@vue/cli-plugin-babel": "~5.0.0",
         "@vue/cli-plugin-eslint": "~5.0.0",
         "@vue/cli-plugin-pwa": "~5.0.0",
@@ -3733,6 +3733,13 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
+      "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/plugin-replace": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
@@ -4817,16 +4824,19 @@
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
-      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.6.tgz",
+      "integrity": "sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.13"
+      },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^5.0.0 || ^6.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "vue": "^3.2.25"
       }
     },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@playwright/test": "^1.59.1",
     "@rollup/plugin-replace": "^6.0.2",
     "@types/node": "^24.10.0",
-    "@vitejs/plugin-vue": "^5.0.0",
+    "@vitejs/plugin-vue": "^6.0.6",
     "@vue/cli-plugin-babel": "~5.0.0",
     "@vue/cli-plugin-eslint": "~5.0.0",
     "@vue/cli-plugin-pwa": "~5.0.0",

--- a/src/components/LuxCard.vue
+++ b/src/components/LuxCard.vue
@@ -164,12 +164,6 @@ export default {
   .lux-text-style {
     padding: 0;
   }
-  :deep(.lux-card-content) {
-    padding: 1rem;
-    @media (min-width: 900px) {
-      padding: var(--space-base);
-    }
-  }
 
   @media (min-width: 600px) {
     .lux-card-header {
@@ -197,6 +191,16 @@ export default {
 
   &:visited {
     color: var(--color-rich-black);
+  }
+}
+</style>
+<style scoped>
+.full-width {
+  :deep(.lux-card-content) {
+    padding: 1rem;
+    @media (min-width: 900px) {
+      padding: var(--space-base);
+    }
   }
 }
 </style>


### PR DESCRIPTION
vue pseudo selector :deep needs to be in a <style scoped> tag
https://vuejs.org/api/sfc-css-features.html#deep-selectors

Fixes the following error in orangelight when we try to upgrade vite 
`bundle exec upgrade vite` in orangelight

[lightningcss minify] 'deep' is not recognized as a valid pseudo-class. Did you mean '::deep' (pseudo-element) or is this a typo?

no changes in lux card

<img width="1132" height="769" alt="Screenshot of the lux-card" src="https://github.com/user-attachments/assets/36083d6b-0e13-4c79-b837-e70b76d86ad5" />




