### PR TITLE
[LuxInputText] Set placeholder default to null.

### DIFF
--- a/src/components/LuxInputText.vue
+++ b/src/components/LuxInputText.vue
@@ -125,7 +125,7 @@ export default {
      */
     placeholder: {
       type: String,
-      default: "",
+      default: null,
     },
     /**
      * The label of the form input field.


### PR DESCRIPTION
[LuxInputText] Set placeholder default to null.
Otherwise we get an empty placeholder attribute in the lux input element that causes the following  accessibility error in orangelight
 when we try to upgrade vite

1) color-contrast: Elements must meet minimum color contrast ratio thresholds (serious)
      https://dequeuniversity.com/rules/axe/4.11/color-contrast?application=axeAPI
      The following 1 node violate this rule:

          Selector: #mce-EMAIL
          HTML: <input data-v-eb11b6c0="" autocomplete="off" name="EMAIL" id="mce-EMAIL" type="email" maxlength="256" hover="false" placeholder="" errormessage="" class="lux-input" value="">
          Fix any of the following:
          - Element has insufficient color contrast of 1.58 (foreground color: #caced3, background color: #ffffff, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1