### PR TITLE
[NewLuxDatePicker] Start basic keyboard navigation

### DIFF
--- a/src/components/_LuxCalendar.vue
+++ b/src/components/_LuxCalendar.vue
@@ -6,7 +6,7 @@
   <LuxInputButton @button-clicked="nextMonth()" type="button" size="small"
     >Next month</LuxInputButton
   >
-  <table>
+  <table class="lux-calendar">
     <tbody>
       <tr>
         <th scope="col">{{ dayName(SUNDAY, props.locale) }}</th>
@@ -24,6 +24,7 @@
           :key="day"
           :class="{
             'lux-day': true,
+            'lux-highlight-focus': focusedDay == day,
             'lux-highlight-today': isToday(day),
             'lux-highlight-selected': isSelected(day),
           }"
@@ -47,7 +48,7 @@ import {
   FRIDAY,
   SATURDAY,
 } from "@/utils/luxDate"
-import { computed, defineModel, ref } from "vue"
+import { computed, defineModel, onDeactivated, onMounted, ref } from "vue"
 import LuxInputButton from "./LuxInputButton.vue"
 
 const JANUARY = 0
@@ -68,6 +69,32 @@ const currentMonth = ref(props.month)
 const currentYear = ref(props.year)
 const calendarWeeks = computed(() => weeks(currentYear.value, currentMonth.value))
 const monthLabel = computed(() => monthName(currentMonth.value, props.locale))
+
+// The day selected with keyboard focus
+const focusedDay = ref(selectedDate.value || new Date().getDate())
+const keydownBehavior = event => {
+  switch (event.key) {
+    case "ArrowDown":
+      focusedDay.value += 7
+      break
+    case "ArrowUp":
+      focusedDay.value -= 7
+      break
+    case "ArrowRight":
+      focusedDay.value += 1
+      break
+    case "ArrowLeft":
+      focusedDay.value -= 1
+      break
+    case "Enter":
+      emitDay(focusedDay.value)
+      break
+  }
+}
+onMounted(() => {
+  document.addEventListener("keydown", keydownBehavior)
+})
+onDeactivated(() => document.removeEventListener("keydown", keydownBehavior))
 
 function previousMonth() {
   if (currentMonth.value == JANUARY) {
@@ -110,6 +137,10 @@ function isSelected(day) {
 }
 </script>
 <style>
+.lux-calendar {
+  border-radius: var(--border-radius-default);
+}
+
 .lux-highlight-today {
   background-color: var(--color-bleu-de-france-darker);
   color: var(--color-white);
@@ -125,5 +156,9 @@ td.lux-day {
   height: var(--lux-cell-size);
   width: var(--lux-cell-size);
   text-align: center;
+}
+
+td.lux-highlight-focus {
+  border: 0.25rem var(--color-princeton-orange-on-white) solid;
 }
 </style>

--- a/tests/unit/specs/components/luxCalendar.spec.js
+++ b/tests/unit/specs/components/luxCalendar.spec.js
@@ -59,4 +59,44 @@ describe("_LuxCalendar", () => {
 
     expect(component.props("modelValue")).toEqual(5)
   })
+  it("can be navigated by arrow keys", async () => {
+    const component = mount(_LuxCalendar, {
+      props: {
+        month: 0,
+        year: 1,
+        modelValue: 1,
+        "onUpdate:modelValue": e => component.setProps({ modelValue: e }),
+      },
+      attachTo: document.body,
+    })
+    const newYearsDay = findDay(component, 1)
+    const january8th = findDay(component, 8)
+    const january9th = findDay(component, 9)
+    const pressKey = async key => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: key }))
+      await nextTick()
+    }
+
+    expect(newYearsDay.classes()).toContain("lux-highlight-focus")
+
+    await pressKey("ArrowDown")
+
+    expect(newYearsDay.classes()).not.toContain("lux-highlight-focus")
+    expect(january8th.classes()).toContain("lux-highlight-focus")
+
+    await pressKey("ArrowRight")
+
+    expect(january8th.classes()).not.toContain("lux-highlight-focus")
+    expect(january9th.classes()).toContain("lux-highlight-focus")
+
+    await pressKey("ArrowLeft")
+
+    expect(january9th.classes()).not.toContain("lux-highlight-focus")
+    expect(january8th.classes()).toContain("lux-highlight-focus")
+
+    await pressKey("ArrowUp")
+
+    expect(january8th.classes()).not.toContain("lux-highlight-focus")
+    expect(newYearsDay.classes()).toContain("lux-highlight-focus")
+  })
 })


### PR DESCRIPTION
Helps with #570

You can now use the arrow keys to move around the calendar.  It still needs work!  For example, if you press the down arrow when you are at the end of the month, the focus will disappear completely rather than paging to the next month 🤣 But opening a PR as incremental progress.