### PR TITLE
Migrate all icon components to composition API

### DIFF
--- a/src/components/icons/LuxIconAdd.vue
+++ b/src/components/icons/LuxIconAdd.vue
@@ -11,18 +11,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconAdd",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconAlert.vue
+++ b/src/components/icons/LuxIconAlert.vue
@@ -22,18 +22,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconAlert",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconApproved.vue
+++ b/src/components/icons/LuxIconApproved.vue
@@ -15,18 +15,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconApproved",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconArrowDown.vue
+++ b/src/components/icons/LuxIconArrowDown.vue
@@ -9,18 +9,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconArrowDown",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconArrowRight.vue
+++ b/src/components/icons/LuxIconArrowRight.vue
@@ -9,18 +9,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconArrowRight",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconArrowUp.vue
+++ b/src/components/icons/LuxIconArrowUp.vue
@@ -8,18 +8,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconArrowUp",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconAscending.vue
+++ b/src/components/icons/LuxIconAscending.vue
@@ -6,18 +6,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconAscending",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/icons/LuxIconBase.vue
+++ b/src/components/icons/LuxIconBase.vue
@@ -23,78 +23,79 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { computed, defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconBase",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-  props: {
-    /**
-     * The name of the icon to display. Also used as the accessible name of the icon.
-     */
-    iconName: {
-      required: false,
-      type: String,
-      default: "",
-    },
-    /**
-     * The width of the icon. For square icons use values of `11px, 13px,
-     * 16px, 24px, 36px, 48px, 64px` to follow visual heirachy set by
-     * typography.
-     */
-    width: {
-      type: [Number, String],
-      default: 24,
-    },
-    /**
-     * The height of the icon. For square icons use values of `11px, 13px,
-     * 16px, 24px, 36px, 48px, 64px` to follow visual heirachy set by
-     * typography.
-     */
-    height: {
-      type: [Number, String],
-      default: 24,
-    },
-    /**
-     * The fill color of the SVG icon.
-     */
-    iconColor: {
-      type: String,
-      default: "currentColor",
-    },
-    /**
-     * If set, put the SVG icon in a circle with the specified color.
-     */
-    circleColor: {
-      type: String,
-    },
-    /**
-     * Hides decorative icon from screen readers
-     */
-    iconHide: {
-      type: [String, Boolean],
-      default: false,
-    },
+})
+
+const props = defineProps({
+  /**
+   * The name of the icon to display. Also used as the accessible name of the icon.
+   */
+  iconName: {
+    required: false,
+    type: String,
+    default: "",
   },
-  computed: {
-    // Present the iconName prop in a format suitable for use as an element's ID.
-    // Only ASCII letters, digits, '_', and '-' should be used in an id, per
-    // https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id
-    iconTitleId() {
-      return this.iconName
-        .toLowerCase()
-        .replace(/[^\w\d\s-_]/g, "")
-        .trim()
-        .replace(/\s/g, "-")
-    },
+  /**
+   * The width of the icon. For square icons use values of `11px, 13px,
+   * 16px, 24px, 36px, 48px, 64px` to follow visual heirachy set by
+   * typography.
+   */
+  width: {
+    type: [Number, String],
+    default: 24,
   },
-}
+  /**
+   * The height of the icon. For square icons use values of `11px, 13px,
+   * 16px, 24px, 36px, 48px, 64px` to follow visual heirachy set by
+   * typography.
+   */
+  height: {
+    type: [Number, String],
+    default: 24,
+  },
+  /**
+   * The fill color of the SVG icon.
+   */
+  iconColor: {
+    type: String,
+    default: "currentColor",
+  },
+  /**
+   * If set, put the SVG icon in a circle with the specified color.
+   */
+  circleColor: {
+    type: String,
+  },
+  /**
+   * Hides decorative icon from screen readers
+   */
+  iconHide: {
+    type: [String, Boolean],
+    default: false,
+  },
+})
+
+// Present the iconName prop in a format suitable for use as an element's ID.
+// Only ASCII letters, digits, '_', and '-' should be used in an id, per
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id
+const iconTitleId = computed(() => {
+  return props.iconName
+    .toLowerCase()
+    .replace(/[^\w\d\s-_]/g, "")
+    .trim()
+    .replace(/\s/g, "-")
+})
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/icons/LuxIconBookmark.vue
+++ b/src/components/icons/LuxIconBookmark.vue
@@ -12,34 +12,36 @@
   Q19 3 18 3
   Z
   "
-    :stroke="lineColor"
+    :stroke="props.lineColor"
     :stroke-width="1.5"
   />
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconBookmark",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-  props: {
-    /**
-     * The outline/stroke color for the bookmark icon.  If not specified,
-     * it will use the iconColor of the parent LuxIconBase component.
-     */
-    lineColor: {
-      required: false,
-      type: String,
-      default: "currentColor",
-    },
+})
+
+const props = defineProps({
+  /**
+   * The outline/stroke color for the bookmark icon.  If not specified,
+   * it will use the iconColor of the parent LuxIconBase component.
+   */
+  lineColor: {
+    required: false,
+    type: String,
+    default: "currentColor",
   },
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconCalendar.vue
+++ b/src/components/icons/LuxIconCalendar.vue
@@ -6,18 +6,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconCalendar",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconClock.vue
+++ b/src/components/icons/LuxIconClock.vue
@@ -15,18 +15,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconClock",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconClose.vue
+++ b/src/components/icons/LuxIconClose.vue
@@ -10,18 +10,19 @@
   />
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconClose",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconConsulting.vue
+++ b/src/components/icons/LuxIconConsulting.vue
@@ -55,18 +55,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconConsulting",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconDelivery.vue
+++ b/src/components/icons/LuxIconDelivery.vue
@@ -25,18 +25,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconDelivery",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconDenied.vue
+++ b/src/components/icons/LuxIconDenied.vue
@@ -21,18 +21,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconDenied",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconDerivativesHealthy.vue
+++ b/src/components/icons/LuxIconDerivativesHealthy.vue
@@ -12,18 +12,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconDerivativesHealthy",
   status: "ready",
   release: "4.1.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconDerivativesUnhealthy.vue
+++ b/src/components/icons/LuxIconDerivativesUnhealthy.vue
@@ -22,18 +22,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconDerivativesUnhealthy",
   status: "ready",
   release: "4.1.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconDescending.vue
+++ b/src/components/icons/LuxIconDescending.vue
@@ -6,18 +6,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconDescending",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/icons/LuxIconEdit.vue
+++ b/src/components/icons/LuxIconEdit.vue
@@ -13,18 +13,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconEdit",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconExclamation.vue
+++ b/src/components/icons/LuxIconExclamation.vue
@@ -12,18 +12,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconExclamation",
   status: "ready",
   release: "3.1.1",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconFile.vue
+++ b/src/components/icons/LuxIconFile.vue
@@ -14,18 +14,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconFile",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconFileHealthy.vue
+++ b/src/components/icons/LuxIconFileHealthy.vue
@@ -36,18 +36,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconFileHealthy",
   status: "ready",
   release: "4.1.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconFileUnhealthy.vue
+++ b/src/components/icons/LuxIconFileUnhealthy.vue
@@ -40,18 +40,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconFileUnhealthy",
   status: "ready",
   release: "4.1.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconFilter.vue
+++ b/src/components/icons/LuxIconFilter.vue
@@ -4,18 +4,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconFilter",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconFlower.vue
+++ b/src/components/icons/LuxIconFlower.vue
@@ -54,18 +54,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconFlower",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconGlobe.vue
+++ b/src/components/icons/LuxIconGlobe.vue
@@ -27,18 +27,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconGlobe",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconHospital.vue
+++ b/src/components/icons/LuxIconHospital.vue
@@ -135,18 +135,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconHospital",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconInfo.vue
+++ b/src/components/icons/LuxIconInfo.vue
@@ -6,18 +6,19 @@
   />
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconInfo",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconLockClose.vue
+++ b/src/components/icons/LuxIconLockClose.vue
@@ -9,18 +9,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconLockClose",
   status: "ready",
   release: "4.1.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconLockOpen.vue
+++ b/src/components/icons/LuxIconLockOpen.vue
@@ -9,18 +9,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconLockOpen",
   status: "ready",
   release: "4.1.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconNewTab.vue
+++ b/src/components/icons/LuxIconNewTab.vue
@@ -11,18 +11,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconNewTab",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconNote.vue
+++ b/src/components/icons/LuxIconNote.vue
@@ -23,18 +23,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconNote",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconPerson.vue
+++ b/src/components/icons/LuxIconPerson.vue
@@ -24,18 +24,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconPerson",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconPicture.vue
+++ b/src/components/icons/LuxIconPicture.vue
@@ -26,18 +26,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconPicture",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconQuestion.vue
+++ b/src/components/icons/LuxIconQuestion.vue
@@ -13,18 +13,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconQuestion",
   status: "ready",
   release: "3.1.1",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconQuestionFilled.vue
+++ b/src/components/icons/LuxIconQuestionFilled.vue
@@ -10,18 +10,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconQuestionFilled",
   status: "ready",
   release: "3.1.1",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconRefresh.vue
+++ b/src/components/icons/LuxIconRefresh.vue
@@ -15,18 +15,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconRefresh",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconRelax.vue
+++ b/src/components/icons/LuxIconRelax.vue
@@ -27,18 +27,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconRelax",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconReportHealthy.vue
+++ b/src/components/icons/LuxIconReportHealthy.vue
@@ -21,18 +21,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconReportHealthy",
   status: "ready",
   release: "4.1.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconReportRemove.vue
+++ b/src/components/icons/LuxIconReportRemove.vue
@@ -56,18 +56,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconReportRemove",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconReportUnhealthy.vue
+++ b/src/components/icons/LuxIconReportUnhealthy.vue
@@ -25,18 +25,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconReportUnhealthy",
   status: "ready",
   release: "4.1.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconReported.vue
+++ b/src/components/icons/LuxIconReported.vue
@@ -50,18 +50,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconReported",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconResearch.vue
+++ b/src/components/icons/LuxIconResearch.vue
@@ -80,18 +80,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconResearch",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconScales.vue
+++ b/src/components/icons/LuxIconScales.vue
@@ -57,18 +57,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconScales",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconSearch.vue
+++ b/src/components/icons/LuxIconSearch.vue
@@ -5,18 +5,19 @@
   />
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconSearch",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconUnsorted.vue
+++ b/src/components/icons/LuxIconUnsorted.vue
@@ -6,18 +6,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconUnsorted",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <style scoped>

--- a/src/components/icons/LuxIconUserHome.vue
+++ b/src/components/icons/LuxIconUserHome.vue
@@ -33,18 +33,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconUserHome",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconVacation.vue
+++ b/src/components/icons/LuxIconVacation.vue
@@ -52,18 +52,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconVacation",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/LuxIconView.vue
+++ b/src/components/icons/LuxIconView.vue
@@ -38,18 +38,19 @@
   </g>
 </template>
 
-<script>
+<script setup>
+import { defineOptions } from "vue"
 /**
  * Icons are used to visually communicate core parts of the product and
  * available actions. Please be aware that all elements must have closing tags (not "self-closing").
  * To add additional icons, please consult [the instructions](/#/Adding%20Icons).
  */
-export default {
+defineOptions({
   name: "LuxIconView",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-}
+})
 </script>
 
 <docs>

--- a/src/components/icons/index.js
+++ b/src/components/icons/index.js
@@ -39,7 +39,7 @@ import LuxIconRelax from "./LuxIconRelax.vue"
 import LuxIconReportHealthy from "./LuxIconReportHealthy.vue"
 import LuxIconReportRemove from "./LuxIconReportRemove.vue"
 import LuxIconReportUnhealthy from "./LuxIconReportUnhealthy.vue"
-import LuxIconReportUserHome from "./LuxIconReportUserHome.vue"
+import LuxIconUserHome from "./LuxIconUserHome.vue"
 import LuxIconReported from "./LuxIconReported.vue"
 import LuxIconResearch from "./LuxIconResearch.vue"
 import LuxIconScales from "./LuxIconScales.vue"
@@ -90,7 +90,7 @@ export {
   LuxIconReportHealthy,
   LuxIconReportRemove,
   LuxIconReportUnhealthy,
-  LuxIconReportUserHome,
+  LuxIconUserHome,
   LuxIconReported,
   LuxIconResearch,
   LuxIconScales,


### PR DESCRIPTION
Note that the LuxIconUserHome component was incorrectly in a file named LuxIconReportUserHome.vue.  Once we switched to the composition API, it no longer displayed in the documentation page with the incorrect filename.  So this PR corrects the filename

Helps with #589