### PR TITLE
Remove or replace several uses of the stack-space SASS mixin

### DIFF
--- a/src/components/LuxAutocompleteInput.vue
+++ b/src/components/LuxAutocompleteInput.vue
@@ -309,6 +309,9 @@ export default {
 $color-placeholder: tint($color-grayscale, 50%);
 
 .lux-autocomplete {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-x-small);
   @include stack-space($space-small);
   font-weight: var(--font-weight-regular);
   font-family: var(--font-family-text);
@@ -325,7 +328,6 @@ $color-placeholder: tint($color-grayscale, 50%);
     display: block;
     font-size: var(--font-size-base);
     color: tint($color-rich-black, 20%);
-    @include stack-space($space-x-small);
 
     &.lux-hidden {
       @include visually-hidden;
@@ -334,7 +336,6 @@ $color-placeholder: tint($color-grayscale, 50%);
 
   input {
     @include inset-squish-space($space-small);
-    @include stack-space($space-small);
     appearance: none;
     -webkit-appearance: none;
     background: var(--color-white);

--- a/src/components/LuxDataTable.vue
+++ b/src/components/LuxDataTable.vue
@@ -277,13 +277,13 @@ export default {
   border-bottom: none;
 
   caption {
-    @include stack-space(var(--space-base));
     display: table-caption;
     text-align: left;
     font-weight: var(--font-weight-bold);
     font-family: var(--font-family-text);
     line-height: var(--line-height-heading);
     font-size: var(--font-size-x-large);
+    margin-block-end: var(--space-base);
   }
 
   thead {

--- a/src/components/LuxLibraryFooter.vue
+++ b/src/components/LuxLibraryFooter.vue
@@ -177,7 +177,6 @@ const theme = computed(() => {
 }
 .lux-library-footer {
   @include reset;
-  @include stack-space(var(--space-base));
   font-family: var(--font-family-heading);
   line-height: var(--line-height-heading);
   color: var(--color-white);

--- a/src/components/LuxLoader.vue
+++ b/src/components/LuxLoader.vue
@@ -51,10 +51,8 @@ export default {
 @use "/src/assets/styles/spacing.scss" as *;
 @use "/src/assets/styles/system.scss" as *;
 
-// $border-color: var(--color-white);
 .lux-loader {
   @include reset;
-  @include stack-space($space-base);
   color: var(--color-rich-black);
   --border-color: var(--color-princeton-orange-on-white);
 }

--- a/src/components/LuxSpecialCollectionsFooter.vue
+++ b/src/components/LuxSpecialCollectionsFooter.vue
@@ -128,7 +128,6 @@ export default {
 
 .lux-special-collections-footer {
   @include reset;
-  @include stack-space(var(--space-base));
   font-family: var(--font-family-heading);
   line-height: var(--line-height-heading);
   color: var(--color-rich-black);

--- a/src/components/LuxTag.vue
+++ b/src/components/LuxTag.vue
@@ -108,7 +108,6 @@ export default {
 @use "/src/assets/styles/system.scss" as *;
 
 .lux-tag {
-  @include stack-space($space-base);
   font-family: var(--font-family-heading);
   line-height: var(--line-height-heading);
   color: var(--color-rich-black);

--- a/src/components/LuxUniversityFooter.vue
+++ b/src/components/LuxUniversityFooter.vue
@@ -109,7 +109,6 @@ export default {
 
 .lux-university-footer {
   @include reset;
-  @include stack-space(var(--space-base));
   font-family: var(--font-family-heading);
   line-height: var(--line-height-heading);
   color: var(--color-white);

--- a/src/components/_LuxLibraryContactInfoOld.vue
+++ b/src/components/_LuxLibraryContactInfoOld.vue
@@ -63,7 +63,10 @@ const props = defineProps({
 
 .lux-library-contact {
   @include reset;
-  @include stack-space(var(--space-x-small));
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-x-small);
+
   font-family: var(--font-family-heading);
   font-size: var(--font-size-base);
   line-height: var(--line-height-base);
@@ -85,7 +88,7 @@ const props = defineProps({
 
 .icons {
   list-style-type: none;
-  margin: 8px 0 0;
+  margin-block: 0 var(--space-x-small);
   padding: 0;
 
   li {

--- a/src/components/_LuxUniversityAccessibility.vue
+++ b/src/components/_LuxUniversityAccessibility.vue
@@ -42,7 +42,6 @@ const props = defineProps({
 
 .lux-accessibility {
   @include reset;
-  @include stack-space(var(--space-base));
   font-family: var(--font-family-heading);
   font-size: var(--font-size-base);
   line-height: var(--line-height-heading);

--- a/src/components/_LuxUniversityAccessibilityOld.vue
+++ b/src/components/_LuxUniversityAccessibilityOld.vue
@@ -34,7 +34,6 @@ const props = defineProps({
 
 .lux-accessibility {
   @include reset;
-  @include stack-space(var(--space-base));
   font-family: var(--font-family-heading);
   font-size: var(--font-size-x-small);
   line-height: var(--line-height-heading);

--- a/src/components/_LuxUniversityCopyright.vue
+++ b/src/components/_LuxUniversityCopyright.vue
@@ -39,7 +39,6 @@ const props = defineProps({
 
 .lux-copyright {
   @include reset;
-  @include stack-space(var(--space-xx-small));
   font-family: var(--font-family-heading);
   font-size: var(--font-size-base);
   line-height: var(--line-height-heading);

--- a/src/components/_LuxUniversityCopyrightOld.vue
+++ b/src/components/_LuxUniversityCopyrightOld.vue
@@ -29,13 +29,9 @@ const props = defineProps({
 })
 </script>
 
-<style lang="scss" scoped>
-@use "/src/assets/styles/spacing.scss" as *;
-@use "/src/assets/styles/mixins.scss" as *;
-
+<style lang="css" scoped>
 .lux-copyright {
-  @include reset;
-  @include stack-space(var(--space-xx-small));
+  margin-block-end: var(--space-xx-small);
   font-family: var(--font-family-heading);
   font-size: var(--font-size-x-small);
   line-height: var(--line-height-heading);

--- a/src/components/_LuxUniversityPrivacyNotice.vue
+++ b/src/components/_LuxUniversityPrivacyNotice.vue
@@ -42,7 +42,6 @@ const props = defineProps({
 
 .lux-privacy-notice {
   @include reset;
-  @include stack-space(var(--space-base));
   font-family: var(--font-family-heading);
   font-size: var(--font-size-base);
   line-height: var(--line-height-heading);


### PR DESCRIPTION
* In several cases, it was not needed at all, since it only applies to vertically stacked elements and many of these were not stacked at all, even on small screens.
* In some cases, this mixin can be replaced by a single margin rule.
* In some cases, this mixin can be replaced by a flex gap