### PR TITLE
Remove duplicate css var --color-light-blue: rgb(203, 221, 230);

### DIFF
--- a/docs/design_tokens.md
+++ b/docs/design_tokens.md
@@ -84,7 +84,6 @@
 |<div class="swatch" style="background-color: rgb(188, 223, 241);"></div>|<pre>--color-sky-blue</pre>|rgb(188, 223, 241);|
 |<div class="swatch" style="background-color: rgb(49, 112, 143);"></div>|<pre>--color-cerulean-blue</pre>|rgb(49, 112, 143);|
 |<div class="swatch" style="background-color: rgb(0, 39, 80);"></div>|<pre>--color-very-dark-blue</pre>|rgb(0, 39, 80);|
-|<div class="swatch" style="background-color: rgb(203, 221, 230);"></div>|<pre>--color-light-blue</pre>|rgb(203, 221, 230);|
 |<div class="swatch" style="background-color: rgb(251, 227, 187);"></div>|<pre>--color-yellow</pre>|rgb(251, 227, 187);|
 |<div class="swatch" style="background-color: rgb(124, 68, 5);"></div>|<pre>--color-dark-yellow</pre>|rgb(124, 68, 5);|
 

--- a/src/assets/styles/variables.css
+++ b/src/assets/styles/variables.css
@@ -50,7 +50,6 @@
   --color-sky-blue: rgb(188, 223, 241);
   --color-cerulean-blue: rgb(49, 112, 143);
   --color-very-dark-blue: rgb(0, 39, 80);
-  --color-light-blue: rgb(203, 221, 230);
   --color-yellow: rgb(251, 227, 187);
   --color-dark-yellow: rgb(124, 68, 5);
   --font-size-large-min: 1.125em;


### PR DESCRIPTION
resolves #614

There is already a css variable `--color-light-blue: rgb(217, 237, 247);` that passes the WCAG 2 AA (Success Criterion 1.4.3) accessibility color contrast test.
The duplicate was added by mistake. 