### PR TITLE
[LuxCalendar] Use buttons to represent calendar days, and set real browser focus instead of a CSS class

### DIFF
--- a/src/components/_LuxCalendar.vue
+++ b/src/components/_LuxCalendar.vue
@@ -2,7 +2,7 @@
   <LuxInputButton @button-clicked="previousMonth()" type="button" size="small"
     >Previous month</LuxInputButton
   >
-  {{ monthLabel }} {{ currentYear }}
+  <span :id="monthId">{{ monthLabel }} {{ currentYear }}</span>
   <LuxInputButton @button-clicked="nextMonth()" type="button" size="small"
     >Next month</LuxInputButton
   >
@@ -24,10 +24,14 @@
           :key="day"
           :class="{
             'lux-day': true,
-            'lux-highlight-focus': focusedDay == day,
             'lux-highlight-today': isToday(day),
             'lux-highlight-selected': isSelected(day),
           }"
+          role="button"
+          :aria-label="day"
+          :aria-describedby="monthId"
+          tabindex="-1"
+          :ref="'day-' + day"
         >
           {{ day }}
         </td>
@@ -49,7 +53,16 @@ import {
   SATURDAY,
   lastDayOfMonth,
 } from "@/utils/luxDate"
-import { computed, defineModel, onDeactivated, onMounted, ref } from "vue"
+import {
+  computed,
+  defineModel,
+  onDeactivated,
+  onMounted,
+  ref,
+  watch,
+  useTemplateRef,
+  useId,
+} from "vue"
 import LuxInputButton from "./LuxInputButton.vue"
 
 const JANUARY = 0
@@ -98,12 +111,18 @@ const keydownBehavior = event => {
 }
 onMounted(() => {
   document.addEventListener("keydown", keydownBehavior)
+  setTimeout(() => dayRefs[focusedDay.value].value[0].focus())
 })
 onDeactivated(() => document.removeEventListener("keydown", keydownBehavior))
 
+const dayRefs = [...Array(32).keys()].map(day => useTemplateRef(`day-${day}`))
+
+watch(focusedDay, value => {
+  setTimeout(() => dayRefs[value].value[0].focus())
+})
+
 function validateFocusedDay() {
   const daysInMonth = lastDayOfMonth(currentYear.value, currentMonth.value)
-  console.log(focusedDay.value, daysInMonth)
   if (focusedDay.value < 1) {
     currentMonth.value = currentMonth.value - 1
     if (currentMonth.value < JANUARY) {
@@ -160,6 +179,9 @@ function isSelected(day) {
     return false
   }
 }
+
+const idPrefix = useId()
+const monthId = `${idPrefix}-month`
 </script>
 <style>
 .lux-calendar {
@@ -183,7 +205,7 @@ td.lux-day {
   text-align: center;
 }
 
-td.lux-highlight-focus {
+td:focus {
   border: 0.25rem var(--color-princeton-orange-on-white) solid;
 }
 </style>

--- a/tests/unit/specs/components/luxCalendar.spec.js
+++ b/tests/unit/specs/components/luxCalendar.spec.js
@@ -1,10 +1,15 @@
 import _LuxCalendar from "@/components/_LuxCalendar.vue"
 import { mount } from "@vue/test-utils"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { nextTick } from "vue"
 
 function findDay(component, day) {
   return component.findAll("td").find(td => td.text() === String(day))
+}
+
+async function pressKey(key) {
+  document.dispatchEvent(new KeyboardEvent("keydown", { key: key }))
+  await nextTick()
 }
 
 describe("_LuxCalendar", () => {
@@ -60,6 +65,7 @@ describe("_LuxCalendar", () => {
     expect(component.props("modelValue")).toEqual(5)
   })
   it("can be navigated by arrow keys", async () => {
+    vi.useFakeTimers()
     const component = mount(_LuxCalendar, {
       props: {
         month: 0,
@@ -69,35 +75,34 @@ describe("_LuxCalendar", () => {
       },
       attachTo: document.body,
     })
+    await nextTick()
+    vi.runAllTimers()
+
     const newYearsDay = findDay(component, 1)
     const january8th = findDay(component, 8)
     const january9th = findDay(component, 9)
-    const pressKey = async key => {
-      document.dispatchEvent(new KeyboardEvent("keydown", { key: key }))
-      await nextTick()
-    }
 
-    expect(newYearsDay.classes()).toContain("lux-highlight-focus")
+    expect(document.activeElement).toEqual(newYearsDay.element)
 
     await pressKey("ArrowDown")
-
-    expect(newYearsDay.classes()).not.toContain("lux-highlight-focus")
-    expect(january8th.classes()).toContain("lux-highlight-focus")
+    await nextTick()
+    vi.runAllTimers()
+    expect(january8th.element).toEqual(document.activeElement)
 
     await pressKey("ArrowRight")
-
-    expect(january8th.classes()).not.toContain("lux-highlight-focus")
-    expect(january9th.classes()).toContain("lux-highlight-focus")
+    await nextTick()
+    vi.runAllTimers()
+    expect(january9th.element).toEqual(document.activeElement)
 
     await pressKey("ArrowLeft")
-
-    expect(january9th.classes()).not.toContain("lux-highlight-focus")
-    expect(january8th.classes()).toContain("lux-highlight-focus")
+    await nextTick()
+    vi.runAllTimers()
+    expect(january8th.element).toEqual(document.activeElement)
 
     await pressKey("ArrowUp")
-
-    expect(january8th.classes()).not.toContain("lux-highlight-focus")
-    expect(newYearsDay.classes()).toContain("lux-highlight-focus")
+    await nextTick()
+    vi.runAllTimers()
+    expect(newYearsDay.element).toEqual(document.activeElement)
   })
   it("can move focus to the first day of the month when the month changes", async () => {
     const component = mount(_LuxCalendar, {
@@ -112,15 +117,16 @@ describe("_LuxCalendar", () => {
 
     const january31st = findDay(component, 31)
 
-    const pressKey = async key => {
-      document.dispatchEvent(new KeyboardEvent("keydown", { key: key }))
-      await nextTick()
-    }
-    expect(january31st.classes()).toContain("lux-highlight-focus")
+    await nextTick()
+    vi.runAllTimers()
+    expect(document.activeElement).toEqual(january31st.element)
     expect(component.text()).toContain("January")
+
     await pressKey("ArrowRight")
     const february1st = findDay(component, 1)
+    await nextTick()
+    vi.runAllTimers()
     expect(component.text()).toContain("February")
-    expect(february1st.classes()).toContain("lux-highlight-focus")
+    expect(february1st.element).toEqual(document.activeElement)
   })
 })


### PR DESCRIPTION
If you use a screen reader, this announces the date as you navigate the calendar with your arrow keys.

Helps with #570 