### PR TITLE
[LuxLibraryLogo] Show focus indicator when the logo has focus

### DIFF
--- a/src/components/LuxLibraryLogo.vue
+++ b/src/components/LuxLibraryLogo.vue
@@ -53,22 +53,28 @@ export default {
     }
   }
   &.light {
-    @include princeton-focus(light);
-    &:hover,
-    &:focus-within {
-      outline-offset: 0.1rem;
+    a {
+      @include princeton-focus(light);
+      &:hover,
+      &:focus-within {
+        outline-offset: 0.1rem;
+      }
     }
   }
   &.dark {
-    @include princeton-focus(dark);
-    &:focus-within {
-      outline-offset: 0.1rem;
+    a {
+      @include princeton-focus(dark);
+      &:focus-within {
+        outline-offset: 0.1rem;
+      }
     }
   }
   &.shade {
-    @include princeton-focus(shade);
-    &:focus-within {
-      outline-offset: 0.1rem;
+    a {
+      @include princeton-focus(shade);
+      &:focus-within {
+        outline-offset: 0.1rem;
+      }
     }
   }
 }


### PR DESCRIPTION
Our focus indicator mixin needed to be on the link, but it was on the link's parent div instead

Closes #444