### PR TITLE
[LuxMediaImage] migrate to composition API

### DIFF
--- a/src/components/LuxMediaImage.vue
+++ b/src/components/LuxMediaImage.vue
@@ -19,7 +19,8 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { defineOptions, ref } from "vue"
 import LuxIconBase from "./icons/LuxIconBase.vue"
 import LuxIconFile from "./icons/LuxIconFile.vue"
 
@@ -27,58 +28,52 @@ import LuxIconFile from "./icons/LuxIconFile.vue"
  * Media-Image is a component that is used to display an image,
  * or an icon if the image can't be resolved.
  */
-export default {
+defineOptions({
   name: "LuxMediaImage",
   status: "ready",
   release: "1.0.0",
   type: "Element",
-  data: function () {
-    return {
-      source: this.src,
-    }
+})
+
+const props = defineProps({
+  /**
+   * The image displayed
+   */
+  src: {
+    type: String,
+    default: null,
   },
-  props: {
-    /**
-     * The image displayed
-     */
-    src: {
-      type: String,
-      default: null,
-    },
-    /**
-     * The alternative text describing the image. Do not include if image is decorative.
-     */
-    alt: {
-      type: String,
-      default: "",
-    },
-    /**
-     * Manually define the height of the image for a card
-     */
-    height: {
-      type: String,
-      default: "",
-    },
-    /**
-     * Whether the image fills the container maintaining aspect ratio and is cropped
-     */
-    cover: {
-      type: Boolean,
-      default: false,
-    },
-    /**
-     * Whether the full image is contained within the container maintaining aspect ratio. Note that this property is not recommened for use when the `height` prop is used as it will show the background of the container.
-     */
-    contain: {
-      type: Boolean,
-      default: false,
-    },
+  /**
+   * The alternative text describing the image. Do not include if image is decorative.
+   */
+  alt: {
+    type: String,
+    default: "",
   },
-  components: {
-    LuxIconBase,
-    LuxIconFile,
+  /**
+   * Manually define the height of the image for a card
+   */
+  height: {
+    type: String,
+    default: "",
   },
-}
+  /**
+   * Whether the image fills the container maintaining aspect ratio and is cropped
+   */
+  cover: {
+    type: Boolean,
+    default: false,
+  },
+  /**
+   * Whether the full image is contained within the container maintaining aspect ratio. Note that this property is not recommened for use when the `height` prop is used as it will show the background of the container.
+   */
+  contain: {
+    type: Boolean,
+    default: false,
+  },
+})
+
+const source = ref(props.src)
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/LuxMediaImage.vue
+++ b/src/components/LuxMediaImage.vue
@@ -73,10 +73,10 @@ export default {
       type: Boolean,
       default: false,
     },
-    components: {
-      LuxIconBase,
-      LuxIconFile,
-    },
+  },
+  components: {
+    LuxIconBase,
+    LuxIconFile,
   },
 }
 </script>

--- a/tests/unit/specs/components/__snapshots__/luxMediaImage.spec.js.snap
+++ b/tests/unit/specs/components/__snapshots__/luxMediaImage.spec.js.snap
@@ -5,13 +5,54 @@ exports[`LuxMediaImage.vue > has the expected html structure 1`] = `
   class="lux-media-image medium lux-default-thumbnail"
   data-v-327f7a2b=""
 >
-  <lux-icon-base-stub
+  <div
+    class="lux-icon"
     data-v-327f7a2b=""
-    height="50"
-    icon-color="rgb(225,225,225)"
-    icon-hide="true"
-    icon-name="file"
-    width="50"
-  />
+    data-v-6dc5806d=""
+  >
+    <svg
+      aria-hidden="true"
+      aria-labelledby="file"
+      color="rgb(225,225,225)"
+      data-v-6dc5806d=""
+      height="50"
+      overflow="visible"
+      role="img"
+      viewBox="0 0 24 24"
+      width="50"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        data-v-6dc5806d=""
+        id="file"
+        lang="en"
+      >
+        file
+      </title>
+      <!--v-if-->
+      <g
+        data-v-6dc5806d=""
+        fill="rgb(225,225,225)"
+      >
+        
+        <g
+          data-v-327f7a2b=""
+        >
+          <g>
+            <path
+              d="M20.5,24h-17C3.2,24,3,23.8,3,23.5v-23C3,0.2,3.2,0,3.5,0h11c0.1,0,0.3,0.1,0.4,0.1l6,6C20.9,6.2,21,6.4,21,6.5v17
+        C21,23.8,20.8,24,20.5,24z M4,23h16V6.7L14.3,1H4V23z"
+            />
+          </g>
+          <g>
+            <path
+              d="M20.5,7h-6C14.2,7,14,6.8,14,6.5v-6C14,0.2,14.2,0,14.5,0S15,0.2,15,0.5V6h5.5C20.8,6,21,6.2,21,6.5S20.8,7,20.5,7z"
+            />
+          </g>
+        </g>
+        
+      </g>
+    </svg>
+  </div>
 </div>
 `;

--- a/tests/unit/specs/components/luxMediaImage.spec.js
+++ b/tests/unit/specs/components/luxMediaImage.spec.js
@@ -14,12 +14,6 @@ describe("LuxMediaImage.vue", () => {
         cover: true,
         contain: false,
       },
-      global: {
-        stubs: {
-          "lux-icon-base": true,
-          "lux-icon-file": true,
-        },
-      },
     })
   })
 
@@ -29,7 +23,7 @@ describe("LuxMediaImage.vue", () => {
     wrapper.setProps({ height: "large" })
     await nextTick()
     expect(mediaimg.classes()).toContain("large")
-    expect(wrapper.find('[icon-name="file"]').exists()).toBe(true)
+    expect(wrapper.find("title").text()).toContain("file")
     expect(wrapper.find("img").exists()).toBe(false)
   })
 
@@ -41,12 +35,6 @@ describe("LuxMediaImage.vue", () => {
         alt: "alt text",
         cover: false,
         contain: true,
-      },
-      global: {
-        stubs: {
-          "lux-icon-base": true,
-          "lux-icon-file": true,
-        },
       },
     })
     expect(wrapper2.find('[name="pul-icon-file"]').exists()).toBe(false)


### PR DESCRIPTION
Also, rewrite tests to avoid stubbing child components.  This allows the tests to more closely resemble what the user would actually see in their browser, and allowed us to catch an issue in the Options API implementation: the components option was inadvertently added to the props rather than the options.