### PR TITLE
Fix accessibility issues

### DIFF
--- a/src/components/icons/LuxIconCreativeCommons.vue
+++ b/src/components/icons/LuxIconCreativeCommons.vue
@@ -1,7 +1,5 @@
 <template>
   <svg
-    version="1.0"
-    id="Layer_1"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns="http://www.w3.org/2000/svg"
     x="0px"
@@ -12,7 +10,7 @@
     :height="height"
     role="img"
     preserveAspectRatio="xMinYMid"
-    aria-labelledby="icon-creative-commons"
+    aria-label="creative commons"
     class="lux-icon-creative-commons"
   >
     <g>

--- a/src/components/icons/LuxIconCreativeCommonsBy.vue
+++ b/src/components/icons/LuxIconCreativeCommonsBy.vue
@@ -1,7 +1,5 @@
 <template>
   <svg
-    version="1.0"
-    id="Layer_1"
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     x="0px"
@@ -13,7 +11,7 @@
     :height="height"
     role="img"
     preserveAspectRatio="xMinYMid"
-    aria-labelledby="icon-creative-commons-by"
+    aria-label="attribution"
     class="lux-icon-creative-commons-by"
   >
     <g>


### PR DESCRIPTION
[LuxIconCreativeCommons]
[LuxIconCreativeCommonsBy]

use aria-label instead of aria-labelledby since
aria-labelledby was not pointing to any elements
Remove id and layer from the svg tag